### PR TITLE
fix: update old payment failed page

### DIFF
--- a/includes/class-flizpay-deactivator.php
+++ b/includes/class-flizpay-deactivator.php
@@ -35,6 +35,30 @@ class Flizpay_Deactivator
 		if ($page) {
 			wp_delete_post($page->ID, true);
 		}
+
+		$page_slug2 = 'flizpay-payment-fail-2';
+		$page2 = get_page_by_path($page_slug2);
+		if ($page2) {
+			wp_delete_post($page2->ID, true);
+		}
+
+		$page_slug3 = 'flizpay-payment-fail-3';
+		$page3 = get_page_by_path($page_slug3);
+		if ($page3) {
+			wp_delete_post($page3->ID, true);
+		}
+
+		$page_slug4 = 'flizpay-payment-fail-4';
+		$page4 = get_page_by_path($page_slug4);
+		if ($page4) {
+			wp_delete_post($page4->ID, true);
+		}
+
+		$payment_failed_slug = 'payment-failed';
+		$payment_failed_page = get_page_by_path($payment_failed_slug);
+		if ($payment_failed_page) {
+			wp_delete_post($payment_failed_page->ID, true);
+		}
 	}
 
 }

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -565,7 +565,7 @@ function flizpay_init_gateway_class()
                 'currency' => $order->get_currency(),
                 'externalId' => $order->get_id(),
                 'successUrl' => $order->get_checkout_order_received_url(),
-                'failureUrl' => get_home_url() . '/flizpay-payment-fail',
+                'failureUrl' => get_home_url() . '/payment-failed',
             );
 
             $client = WC_Flizpay_API::get_instance($api_key);

--- a/includes/class-flizpay.php
+++ b/includes/class-flizpay.php
@@ -81,6 +81,28 @@ class Flizpay
 		$this->define_admin_hooks();
 		$this->define_public_hooks();
 
+		$this->update_old_payment_failed_page();
+	}
+
+	public function update_old_payment_failed_page()
+	{
+		try {
+			$page_slug = 'flizpay-payment-fail';
+			$page = get_page_by_path($page_slug);
+			$page_slug2 = 'flizpay-payment-fail-2';
+			$page2 = get_page_by_path($page_slug2);
+			$page_slug3 = 'flizpay-payment-fail-3';
+			$page3 = get_page_by_path($page_slug3);
+			$page_slug4 = 'flizpay-payment-fail-4';
+			$page4 = get_page_by_path($page_slug4);
+
+			if ($page || $page2 || $page3 || $page4) {
+				Flizpay_Deactivator::deactivate();
+				Flizpay_Activator::activate();
+			}
+		} catch (Exception $e) {
+
+		}
 	}
 
 	/**
@@ -101,6 +123,16 @@ class Flizpay
 	 */
 	private function load_dependencies()
 	{
+
+		/**
+		 * The class responsible for activating the plugin
+		 */
+		require_once plugin_dir_path(dirname(__FILE__)) . 'includes/class-flizpay-activator.php';
+
+		/**
+		 * The class responsible for deactivating the plugin
+		 */
+		require_once plugin_dir_path(dirname(__FILE__)) . 'includes/class-flizpay-deactivator.php';
 
 		/**
 		 * The class responsible for orchestrating the actions and filters of the
@@ -243,5 +275,7 @@ class Flizpay
 	{
 		return $this->version;
 	}
+
+
 
 }


### PR DESCRIPTION
- Call deactivator and activator to remove old pages on plugin load if the old page is present
- Redirect to new failure page on payment failed