### PR TITLE
feat: switch to our failed page

### DIFF
--- a/includes/class-flizpay-activator.php
+++ b/includes/class-flizpay-activator.php
@@ -24,77 +24,12 @@ class Flizpay_Activator
 {
 
     /**
-     * Activate FLIZpay by adding the custom payment failure page. (use period)
-     *
-     * Adds a post page to be used when payment fails and register a filter and an action
-     * to exclude it from the navigation menu and search results.
+     * Activate FLIZpay 
      *
      * @since    1.0.0
      */
     public static function activate()
     {
-        // Create post object
-        $flizpay_fail = array(
-            'post_title' => wp_strip_all_tags('Payment Failed'),
-            'post_content' => 'Your payment has failed and the order has been canceled. Please try again.',
-            'post_status' => 'publish',
-            'post_author' => 1,
-            'post_type' => 'page',
-            'meta_input' => array(
-                '_flizpay_system_page' => true // Custom meta key to identify the page
-            ),
-        );
 
-        // Insert the post into the database
-        $flizpay_fail_id = wp_insert_post($flizpay_fail);
-
-        add_filter('wp_get_nav_menu_items', 'flizpay_exclude_menu_items', 10, 3);
-        add_action('pre_get_posts', 'flizpay_exclude_pages_from_search');
-
-        // Hook to add SEO exclusion meta tag for this page
-        add_action('wp_head', function () use ($flizpay_fail_id) {
-            if (is_page($flizpay_fail_id)) {
-                echo '<meta name="robots" content="noindex, nofollow">';
-            }
-        });
-
-    }
-
-    /** 
-     * Filter for excluding the payment failed page from the navigation menu
-     * 
-     * @return array
-     * 
-     * @since 1.0.0
-     */
-    function flizpay_exclude_menu_items($items, $menu, $args)
-    {
-        foreach ($items as $key => $item) {
-            if (get_post_meta($item->object_id, '_flizpay_system_page', true)) {
-                unset($items[$key]);
-            }
-        }
-        return $items;
-    }
-
-    /**
-     * Action for excluding the payment failed page from search results
-     * @param mixed $query
-     * @return mixed
-     * 
-     * @since 1.0.0
-     */
-    function flizpay_exclude_pages_from_search($query)
-    {
-        if ($query->is_search && !is_admin()) {
-            $meta_query = array(
-                array(
-                    'key' => '_flizpay_system_page',
-                    'compare' => 'NOT EXISTS',
-                ),
-            );
-            $query->set('meta_query', $meta_query);
-        }
-        return $query;
     }
 }

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -565,7 +565,7 @@ function flizpay_init_gateway_class()
                 'currency' => $order->get_currency(),
                 'externalId' => $order->get_id(),
                 'successUrl' => $order->get_checkout_order_received_url(),
-                'failureUrl' => get_home_url() . '/payment-failed',
+                'failureUrl' => 'https://checkout.flizpay.de/failed',
             );
 
             $client = WC_Flizpay_API::get_instance($api_key);

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -456,16 +456,12 @@ function flizpay_init_gateway_class()
                     $order->calculate_totals();
                     $order->save();
                     $order->add_order_note('FLIZ Cashback Applied: ' . $data['currency'] . sanitize_text_field($fliz_discount));
+                    WC()->cart->empty_cart();
                 }
-
-                WC()->cart->empty_cart();
 
                 if (isset($data['transactionId'])) {
                     $order->add_order_note('FLIZ transaction ID: ' . sanitize_text_field($data['transactionId']));
                 }
-            } else if ($status === 'failed') {
-                $order->cancel_order();
-                $order->update_status('cancelled', 'Updated via FLIZpay plugin', true);
             } else {
                 return;
             }

--- a/includes/class-flizpay.php
+++ b/includes/class-flizpay.php
@@ -103,8 +103,10 @@ class Flizpay
 			$page3 = get_page_by_path($page_slug3);
 			$page_slug4 = 'flizpay-payment-fail-4';
 			$page4 = get_page_by_path($page_slug4);
+			$page_slug5 = 'payment-failed';
+			$page5 = get_page_by_path($page_slug5);
 
-			if ($page || $page2 || $page3 || $page4) {
+			if ($page || $page2 || $page3 || $page4 || $page5) {
 				Flizpay_Deactivator::deactivate();
 				Flizpay_Activator::activate();
 			}

--- a/public/class-flizpay-public.php
+++ b/public/class-flizpay-public.php
@@ -110,7 +110,7 @@ class Flizpay_Public
             echo wp_json_encode(
                 array(
                     'status' => $status,
-                    'url' => $status === 'processing' ? $order->get_checkout_order_received_url() : get_home_url() . '/payment-failed',
+                    'url' => $status === 'processing' ? $order->get_checkout_order_received_url() : 'https://checkout.flizpay.de/failed',
                 )
             );
         }


### PR DESCRIPTION
[Notion Ticket](https://www.notion.so/Move-our-payment-failed-functionality-to-our-checkout-page-1290aa2641a78058a5e5c7d994958046)

- We'll use our own failed page to handle payment failed. 
- We'll also not empty the cart and cancel the order when it's payment failed