### PR TITLE
feat: use user locale on admin page

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@
 Contributors: Flizpay
 Tags: kostenlos, payments, Zahlung, cashback, no-fee
 Requires at least: 4.4
-Tested up to: 6.6.1
+Tested up to: 6.7
 Stable tag: 1.3.0
 Requires PHP: 7.0
 License: GPLv2 or later

--- a/admin/class-flizpay-admin.php
+++ b/admin/class-flizpay-admin.php
@@ -90,7 +90,7 @@ class Flizpay_Admin
 			'nonce' => wp_create_nonce('test_connection_nonce'),
 			'loading_icon' => "$this->assets_url/loading.svg",
 			'example_image' => $this->is_english() ? "$this->assets_url/flizpay-checkout-example-en.png" : "$this->assets_url/flizpay-checkout-example-de.png",
-			'wp_locale' => get_locale()
+			'wp_locale' => get_user_locale() ?? get_locale()
 		));
 
 	}
@@ -115,7 +115,7 @@ class Flizpay_Admin
 
 	public function is_english()
 	{
-		return str_contains(get_locale(), 'en');
+		return str_contains(get_user_locale() ?? get_locale(), 'en');
 	}
 
 	/**

--- a/flizpay.php
+++ b/flizpay.php
@@ -13,7 +13,7 @@
  * @package           Flizpay
  *
  * @wordpress-plugin
- * Plugin Name:       FLIZpay
+ * Plugin Name:       FLIZpay Gateway für WooCommerce
  * Plugin URI:        https://www.flizpay.de/companies
  * Description:       FLIZpay: 100% free!
  * Version:           1.3.0


### PR DESCRIPTION
## Description

- Use the `get_user_locale` function on admin page translations when available 
- Fix wordpress tested version to the newest one 
- Fix plugin name consistency on readme and plugin header

---


## Tests

- [x] Use admin page in a language different from generic config

---
---