### PR TITLE
fix: add support to variations product

### DIFF
--- a/public/css/flizpay-public.css
+++ b/public/css/flizpay-public.css
@@ -85,3 +85,18 @@
 .fliz-highlight-text {
   text-shadow: 0px 0px 4px #80ED99;
 }
+
+.flizpay-express-checkout-button.disabled {
+  cursor: not-allowed;
+  filter: grayscale(100%);
+
+  &:hover {
+    cursor: not-allowed;
+    filter: grayscale(100%);
+  }
+
+  &:active {
+    cursor: not-allowed;
+    filter: grayscale(100%);
+  }
+}


### PR DESCRIPTION
## Description

- Consider the different product variations that could exist during the express checkout in the product page. 
Make sure our button is disabled like the other ones when the variations are not selected

---


## Tests

- [x] Express checkout a product with variation
- [x] Express checkotu a product without variation


## Notion Ticket
[Link to Notion ticket](https://www.notion.so/Express-checkout-popup-and-e-mail-prompt-13b0aa2641a780d388b1d90573a19df8?pvs=4)

---