### PR TITLE
Feat: add discount to checkout page

### DIFF
--- a/includes/class-flizpay-api.php
+++ b/includes/class-flizpay-api.php
@@ -52,7 +52,7 @@ class WC_Flizpay_API
    */
   private function init()
   {
-    $this->base_url = 'http://localhost:8080';
+    $this->base_url = 'https://api.flizpay.de';
     $this->routes = array(
       'generate_webhook_key' => function ($body) {
         return array(

--- a/includes/class-flizpay-api.php
+++ b/includes/class-flizpay-api.php
@@ -52,7 +52,7 @@ class WC_Flizpay_API
    */
   private function init()
   {
-    $this->base_url = 'https://api.flizpay.de';
+    $this->base_url = 'http://localhost:8080';
     $this->routes = array(
       'generate_webhook_key' => function ($body) {
         return array(

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -317,7 +317,7 @@ function flizpay_init_gateway_class()
                 }
             }
 
-            return !empty($cashback_data) ? $cashback_data : null;
+            return !empty($cashback_data) && floatval($cashback_data) > 0 ? $cashback_data : null;
         }
 
         /**

--- a/public/class-flizpay-public.php
+++ b/public/class-flizpay-public.php
@@ -87,6 +87,7 @@ class Flizpay_Public
                 'ajaxurl' => admin_url('admin-ajax.php'),
                 'public_dir_path' => plugin_dir_url(__FILE__),
                 'order_finish_nonce' => wp_create_nonce('order_finish_nonce'),
+                'cashback' => get_transient('flizpay_cashback_transient'),
             );
             wp_localize_script($this->plugin_name, "flizpay_frontend", $ajaxurl);
         }

--- a/public/js/flizpay-public.js
+++ b/public/js/flizpay-public.js
@@ -206,11 +206,12 @@ jQuery(function ($) {
           );
 
         // Initialize the original total value
-        //if (flizpay_frontend.website_language.includes("de"))
         originalTotal = parseFloat(currentValue).toFixed(2);
-        //else originalTotal = parseFloat(currentValue * 100).toFixed(2);
 
-        if (paymentRadioElement && paymentRadioElement.checked) {
+        if (
+          paymentRadioElement &&
+          document.querySelector(paymentRadioSelector).checked
+        ) {
           const discountedValue = (
             originalTotal -
             originalTotal * parseFloat(cashback / 100)
@@ -300,7 +301,10 @@ jQuery(function ($) {
         );
         originalTotal = currentValue.toFixed(2);
 
-        if (paymentRadioElement && paymentRadioElement.checked) {
+        if (
+          paymentRadioElement &&
+          document.querySelector(paymentRadioSelector).checked
+        ) {
           const discountedValue = (
             originalTotal -
             originalTotal * parseFloat(cashback / 100)

--- a/public/js/flizpay-public.js
+++ b/public/js/flizpay-public.js
@@ -180,19 +180,28 @@ jQuery(function ($) {
       const paymentRadioSelector =
         "#radio-control-wc-payment-method-options-flizpay";
       const orderTotalSelector = ".wc-block-components-totals-item__value";
+      const taxSelector = ".wc-block-components-totals-footer-item-tax";
       const paymentRadioElement = document.querySelector(paymentRadioSelector);
       const orderTotalElement = document.querySelectorAll(orderTotalSelector);
       const productsTotal = orderTotalElement[0];
-      const shipmentTotal = orderTotalElement[1];
-      const totalDesktop = orderTotalElement[2];
-      const totalMobile = orderTotalElement[3];
       const cashback = parseFloat(flizpay_frontend.cashback);
+      const taxElement = document.querySelectorAll(taxSelector);
+      const taxDesktop = taxElement[0];
+      const taxMobile = taxElement[1];
+      const originalTax = taxDesktop?.innerHTML || taxMobile?.innerHTML;
 
       let originalTotal = null; // Track the original total value
       let isUpdating = false; // Flag to prevent loop
 
       // Function to update the order total
       const updateOrderTotal = () => {
+        // Duplicate it for on the fly checks
+        const orderTotalElement = document.querySelectorAll(orderTotalSelector);
+        const productsTotal = orderTotalElement[0];
+        const shipmentTotal = orderTotalElement[1];
+        const totalDesktop = orderTotalElement[2];
+        const totalMobile = orderTotalElement[3];
+
         if (!productsTotal || !shipmentTotal || isUpdating) return;
 
         isUpdating = true;
@@ -226,14 +235,21 @@ jQuery(function ($) {
             ".",
             ","
           )} €</strike> ${discountedValue.replace(".", ",")} €`;
+          const discountedTaxLabel = navigator.language.includes("en")
+            ? 'Incl. 19% VAT.'
+            : 'Inkl. 19% MwSt.'
 
           if (totalDesktop) totalDesktop.innerHTML = discountedLabel;
           if (totalMobile) totalMobile.innerHTML = discountedLabel;
+          if (taxDesktop) taxDesktop.innerHTML = discountedTaxLabel;
+          if (taxMobile) taxMobile.innerHTML = discountedTaxLabel;
         } else {
           const originalLabel = `${originalTotal.replace(".", ",")} €`;
 
           if (totalDesktop) totalDesktop.innerHTML = originalLabel;
           if (totalMobile) totalMobile.innerHTML = originalLabel;
+          if (taxDesktop) taxDesktop.innerHTML = originalTax;
+          if (taxMobile) taxMobile.innerHTML = originalTax;
         }
 
         setTimeout(() => {
@@ -284,8 +300,13 @@ jQuery(function ($) {
       const paymentRadioSelector = "#payment_method_flizpay";
       const orderTotalSelector =
         "#order_review > table > tfoot > tr.order-total > td > strong > span > bdi";
+      const gmTaxSelector = "#order_review > table > tfoot > tr.order-total > td > span"
+      const defaultTaxSelector = "#order_review > table > tfoot > tr.order-tax"
+      
       const paymentRadioElement = document.querySelector(paymentRadioSelector);
       const orderTotalElement = document.querySelector(orderTotalSelector);
+      const taxElement = document.querySelector(gmTaxSelector) || document.querySelector(defaultTaxSelector);
+      const originalTax = taxElement?.innerHTML;
       const cashback = parseFloat(flizpay_frontend.cashback);
 
       let originalTotal = null; // Track the original total value
@@ -297,7 +318,7 @@ jQuery(function ($) {
         isUpdating = true;
 
         const currentValue = parseFloat(
-          orderTotalElement.textContent.replace(".", "").replace(",", ".")
+          document.querySelector(orderTotalSelector).textContent.replace(".", "").replace(",", ".")
         );
         originalTotal = currentValue.toFixed(2);
 
@@ -320,10 +341,15 @@ jQuery(function ($) {
             ","
           )} €</strike> ${discountedValue.replace(".", ",")} €`;
 
-          orderTotalElement.innerHTML = discountedLabel;
+          document.querySelector(orderTotalSelector).innerHTML =
+            discountedLabel;
+          taxElement.innerHTML = navigator.language.includes("en")
+            ? 'Incl. 19% VAT.'
+            : 'Inkl. 19% MwSt.'
         } else {
           const originalLabel = `${originalTotal.replace(".", ",")} €`;
-          orderTotalElement.innerHTML = originalLabel;
+          document.querySelector(orderTotalSelector).innerHTML = originalLabel;
+          taxElement.innerHTML = originalTax;
         }
 
         setTimeout(() => {

--- a/public/js/flizpay-public.js
+++ b/public/js/flizpay-public.js
@@ -375,7 +375,7 @@ jQuery(function ($) {
       }
 
       // Observe changes to the order total element
-      if (productsTotal) {
+      if (orderTotalElement) {
         const orderObserver = new MutationObserver(() => {
           if (!isUpdating) updateOrderTotal();
         });

--- a/public/js/flizpay-public.js
+++ b/public/js/flizpay-public.js
@@ -90,9 +90,9 @@ jQuery(function ($) {
             }
           }
         });
-
-        adjust_fliz_totals_classic();
       });
+
+      adjust_fliz_totals_classic();
     }
 
     function updateLocalStorage(order_id) {


### PR DESCRIPTION
## Description

- Edits the checkout page totals to display the discounted amount on the order total when fliz is selected as a payment method and the discount is greater than 1 EUR. 


---


## Tests - TODO

- [x] Tested locally on blocks plugin
- [x] Tested in Staging with Flizpay.store plugin blocks
- [x] Tested in Staging with Marbled Works plugin classic

---

## Screenshots / Videos
If there are any UI changes please add screenshots or videos:

1. 

https://github.com/user-attachments/assets/82395e2f-249d-4551-9ddb-a57a77aeffa1



## Notion Ticket
[Link to Notion ticket](https://www.notion.so/Show-the-discounted-value-in-the-checkout-page-1460aa2641a780f3a0f9ec1d6761ade1?pvs=4)

---