### PR TITLE
feat: add status draft to order when created

### DIFF
--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -558,6 +558,8 @@ function flizpay_init_gateway_class()
         public function process_payment($order_id)
         {
             $order = wc_get_order($order_id);
+            $order->set_status('wc-checkout-draft', 'Waiting FLIZpay payment');
+            $order->save();
 
             $redirectUrl = $this->create_transaction($order);
 

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -558,6 +558,7 @@ function flizpay_init_gateway_class()
         public function process_payment($order_id)
         {
             $order = wc_get_order($order_id);
+            // We set the status as draft here to avoid accountability softwares picking the Pending Payment order
             $order->set_status('wc-checkout-draft', 'Waiting FLIZpay payment');
             $order->save();
 


### PR DESCRIPTION
## Description

- To avoid accounting softwares picking orders in status Pending Payment we'll create the order as draft

---


## Tests

- [x] Make a Payment

---