### PR TITLE
Feat/add shipping api

### DIFF
--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -483,6 +483,7 @@ function flizpay_init_gateway_class()
             $number = $shipping_info['number'];
             $firstName = $shipping_info['firstName'];
             $lastName = $shipping_info['lastName'];
+            $email = $shipping_info['email'];
 
             $order = wc_get_order($order_id);
             if (!$order) {
@@ -500,8 +501,12 @@ function flizpay_init_gateway_class()
                 'state' => '', // Optional: Set state if available
                 'postcode' => $zip_code,
                 'country' => $country,
+                'email' => $order->get_billing_email() || $email
             ];
             $order->set_address($address, 'shipping');
+            $order->set_billing_first_name($order->get_billing_first_name() || $firstName);
+            $order->set_billing_last_name($order->get_billing_last_name() || $lastName);
+            $order->set_billing_email($order->get_billing_email() || $email);
             $order->save();
 
             // Calculate available shipping methods

--- a/public/class-flizpay-public.php
+++ b/public/class-flizpay-public.php
@@ -144,6 +144,7 @@ class Flizpay_Public
             'dark_icon' => $this->assets_url . '/fliz-express-checkout-logo-dark.svg',
             'fliz_logo' => $this->assets_url . '/fliz-logo.svg',
             'fliz_loading_wheel' => $this->assets_url . '/fliz-loading-wheel.svg',
+            'cashback' => get_transient('flizpay_cashback_transient'),
         );
         wp_localize_script($this->plugin_name, "flizpay_frontend", $variables);
     }


### PR DESCRIPTION
## Description

- Add API for getting shipping info given the customer address and return the available methods its ids and costs. 
- Add API for setting the shipping method of the customer's choice given its ID and returning the total order cost

---


## Notion Ticket
[Link to Notion ticket](https://www.notion.so/Merchant-config-on-transaction-and-payment-completion-13b0aa2641a780238d7ad0ad084832b7?pvs=4)

---