### PR TITLE
feat: remove the webhook url on uninstall

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -12,7 +12,7 @@ $api_key = $flizpay_settings['flizpay_api_key'];
 
 $api_client = WC_Flizpay_API::get_instance($api_key);
 
-$api_client->dispatch('uninstall', array("webhookUrl" => ''));
+$api_client->dispatch('save_webhook_url', array("webhookUrl" => ''));
 
 // Clean up options
 $options = array(

--- a/uninstall.php
+++ b/uninstall.php
@@ -4,6 +4,16 @@ if (!defined('WP_UNINSTALL_PLUGIN')) {
 	exit;
 }
 
+require_once('includes/class-flizpay-api.php');
+
+$flizpay_settings = get_option('woocommerce_flizpay_settings');
+error_log(json_encode($flizpay_settings));
+$api_key = $flizpay_settings['flizpay_api_key'];
+
+$api_client = WC_Flizpay_API::get_instance($api_key);
+
+$api_client->dispatch('uninstall', array("webhookUrl" => ''));
+
 // Clean up options
 $options = array(
 	'flizpay_api_key',


### PR DESCRIPTION
## Description

- In order to keep track of who has the plugin still installed, we need to remove the webhook URL once it gets uninstalled

---


## Tests

- [x] Removed the plugin locally 

---


## Depends on

[backend-#311](https://github.com/Flizpay/backend/pull/311)
