### PR TITLE
fix: dont use api mode on the api dispatch

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -12,7 +12,7 @@ $api_key = $flizpay_settings['flizpay_api_key'];
 
 $api_client = WC_Flizpay_API::get_instance($api_key);
 
-$api_client->dispatch('save_webhook_url', array("webhookUrl" => ''));
+$api_client->dispatch('save_webhook_url', array("webhookUrl" => ''), false);
 
 // Clean up options
 $options = array(


### PR DESCRIPTION
## Description

- Users cant delete plugin when no api key is set due to the api mode on the api client returning the error instantly

---


## Tests

- [x] Deleted the plugin on marble works
- [x] Deleted the plugin on flizpay.store

---


## Notion Ticket
[Link to Notion ticket](https://www.notion.so/Fix-you-cant-delete-plugin-1730aa2641a7806aa90dd5caa80d43ea?pvs=4)

---