### PR TITLE
feat: set business as inactive on deactivation

### DIFF
--- a/includes/class-flizpay-activator.php
+++ b/includes/class-flizpay-activator.php
@@ -30,6 +30,13 @@ class Flizpay_Activator
      */
     public static function activate()
     {
+        require_once('includes/class-flizpay-api.php');
 
+        $flizpay_settings = get_option('woocommerce_flizpay_settings');
+        $api_key = $flizpay_settings['flizpay_api_key'];
+
+        $api_client = WC_Flizpay_API::get_instance($api_key);
+
+        $api_client->dispatch('save_webhook_url', array("woocommerceActive" => true), false);
     }
 }

--- a/includes/class-flizpay-deactivator.php
+++ b/includes/class-flizpay-deactivator.php
@@ -59,6 +59,15 @@ class Flizpay_Deactivator
 		if ($payment_failed_page) {
 			wp_delete_post($payment_failed_page->ID, true);
 		}
+
+		require_once('includes/class-flizpay-api.php');
+
+		$flizpay_settings = get_option('woocommerce_flizpay_settings');
+		$api_key = $flizpay_settings['flizpay_api_key'];
+
+		$api_client = WC_Flizpay_API::get_instance($api_key);
+
+		$api_client->dispatch('save_webhook_url', array("woocommerceActive" => false), false);
 	}
 
 }


### PR DESCRIPTION
## Description

- Set business as inactive when plugin is deactivated

---

## Notion Ticket
[Link to Notion ticket](https://www.notion.so/If-someone-connects-webhool-url-add-isActive-true-if-someone-de-activates-or-deletes-plugin-isActi-1770aa2641a780c98722db9db382b931?pvs=4)

---