### PR TITLE
feat: return products on create_transaction's body

### DIFF
--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -934,6 +934,26 @@ function flizpay_init_gateway_class()
                 'firstName' => $order->get_billing_first_name(),
                 'lastName' => $order->get_billing_last_name()
             );
+            $products = array();
+            foreach ( $order->get_items() as $item_id => $item ) {
+                $product = $item->get_product();
+                if ( !$product ) {
+                    continue; 
+                }
+  
+                $name    = $product->get_name();
+                $amount  = $item->get_quantity();
+                $price   = $product->get_price(); // or use $item->get_subtotal() depending on how you want to handle pricing
+                $img_id  = $product->get_image_id();
+                $picture = wp_get_attachment_image_url( $img_id, 'full' );
+        
+                $products[] = array(
+                    'name'    => $name,
+                    'amount'  => $amount,
+                    'price'   => $price,
+                    'picture' => $picture ? $picture : ''
+                );
+            }
             $body = array(
                 'amount' => $order->get_total(),
                 'currency' => $order->get_currency(),
@@ -941,7 +961,8 @@ function flizpay_init_gateway_class()
                 'successUrl' => $order->get_checkout_order_received_url(),
                 'failureUrl' => 'https://checkout.flizpay.de/failed',
                 'customer' => $customer,
-                'source' => $source
+                'source' => $source,
+                'products' => $products,  
             );
             $client = WC_Flizpay_API::get_instance($api_key);
 

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -945,13 +945,11 @@ function flizpay_init_gateway_class()
                 $amount  = $item->get_quantity();
                 $price   = $product->get_price(); // or use $item->get_subtotal() depending on how you want to handle pricing
                 $img_id  = $product->get_image_id();
-                $picture = wp_get_attachment_image_url( $img_id, 'full' );
         
                 $products[] = array(
                     'name'    => $name,
                     'amount'  => $amount,
                     'price'   => $price,
-                    'picture' => $picture ? $picture : ''
                 );
             }
             $body = array(

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -943,7 +943,7 @@ function flizpay_init_gateway_class()
   
                 $name    = $product->get_name();
                 $amount  = $item->get_quantity();
-                $price   = $product->get_subtotal();
+                $price   = $product->get_price(); 
         
                 $products[] = array(
                     'name'    => $name,

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -943,8 +943,7 @@ function flizpay_init_gateway_class()
   
                 $name    = $product->get_name();
                 $amount  = $item->get_quantity();
-                $price   = $product->get_price(); // or use $item->get_subtotal() depending on how you want to handle pricing
-                $img_id  = $product->get_image_id();
+                $price   = $product->get_subtotal();
         
                 $products[] = array(
                     'name'    => $name,


### PR DESCRIPTION
## Description

- Add "products" on the body of create_transcation function. The "products" is an Array of objects comming from the woocommerce cart.

---

## Tests

- [x] Ensured the products were being passed foward to the checkout page.
 
---

## Notion Ticket
[Ticket](https://www.notion.so/Add-sub-items-to-checkout-page-from-cart-and-also-some-sort-of-line-explaining-that-shipping-will-c-1770aa2641a7806fa638d27d62d15f0e)

---