### PR TITLE
fix: dont return before saving order when finishing the payment

### DIFF
--- a/includes/class-flizpay-webhook-helper.php
+++ b/includes/class-flizpay-webhook-helper.php
@@ -67,8 +67,6 @@ class Flizpay_Webhook_Helper
 
     if ($status === 'completed') {
       $this->complete_order($order, $data);
-    } else {
-      return;
     }
 
     $order->save();


### PR DESCRIPTION
## Description

- We were returning in case order was not successful, before saving the order. Now it will save the order for payment failed

---