### PR TITLE
feat: add shippable flag to transaction creation

### DIFF
--- a/includes/class-flizpay-api-service.php
+++ b/includes/class-flizpay-api-service.php
@@ -72,7 +72,8 @@ class Flizpay_API_Service
       'failureUrl' => 'https://checkout.flizpay.de/failed',
       'customer' => $customer,
       'source' => $source,
-      'products' => $this->get_products($order)
+      'products' => $this->get_products($order),
+      'needsShipping' => $this->needs_shipping($order)
     ];
     $client = WC_Flizpay_API::get_instance($this->api_key);
     $response = $client->dispatch('create_transaction', $body, false);
@@ -102,5 +103,20 @@ class Flizpay_API_Service
     }
 
     return $products;
+  }
+
+  public function needs_shipping($order)
+  {
+    foreach ($order->get_items() as $item_id => $item) {
+      $product = $item->get_product();
+      if (!$product) {
+        continue;
+      }
+
+      if (!$product->needs_shipping())
+        return false;
+    }
+
+    return true;
   }
 }


### PR DESCRIPTION
## Description
Please describe the changes made in this PR:

- Added a flag to indicate when the transaction needs shipping based on the classification of the merchant products
---


## Tests
Please add the tests you've done:

- [x] Localhost
- [x] Flizpay.store

---

## Notion Ticket
[Link to Notion ticket](https://www.notion.so/Investigate-which-shipping-configuration-creates-a-problem-when-retrieving-shipping-options-on-expre-19b0aa2641a780d0a3ebefa33bb5fc4d?pvs=4)

---