### PR TITLE
feat: update plugin version on activation and upgrade

### DIFF
--- a/flizpay.php
+++ b/flizpay.php
@@ -91,8 +91,19 @@ function flizpay_deactivate()
 	Flizpay_Deactivator::deactivate();
 }
 
+function flizpay_upgrader($upgrader, $options)
+{
+	$plugin = plugin_basename(__FILE__);
+
+	if ($options['action'] == 'update' && $options['type'] == 'plugin' && $options['plugins'][0] == $plugin) {
+		require_once plugin_dir_path(__FILE__) . 'includes/class-flizpay-activator.php';
+		Flizpay_Activator::activate();
+	}
+}
+
 register_activation_hook(__FILE__, 'flizpay_activate');
 register_deactivation_hook(__FILE__, 'flizpay_deactivate');
+add_action('upgrader_process_complete', 'flizpay_upgrader');
 
 /**
  * The core plugin class that is used to define internationalization,

--- a/includes/class-flizpay-activator.php
+++ b/includes/class-flizpay-activator.php
@@ -44,6 +44,6 @@ class Flizpay_Activator
 
         $api_client = WC_Flizpay_API::get_instance($api_key);
 
-        $api_client->dispatch('edit_business', array("isActive" => true), false);
+        $api_client->dispatch('edit_business', array("isActive" => true, "pluginVersion" => FLIZPAY_VERSION), false);
     }
 }

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -1,4 +1,8 @@
 <?php
+if (!defined('FLIZPAY_VERSION')) {
+    define('FLIZPAY_VERSION', '2.1.0');
+}
+
 /**
  * The Payment Gateway class itself, please note that it is inside plugins_loaded action hook
  */
@@ -8,7 +12,7 @@ function flizpay_init_gateway_class()
 
     class WC_Flizpay_Gateway extends WC_Payment_Gateway
     {
-        static $VERSION = "2.1.0";
+        public static $VERSION = FLIZPAY_VERSION;
 
         public $icon;
         public $title;

--- a/includes/class-flizpay.php
+++ b/includes/class-flizpay.php
@@ -50,15 +50,6 @@ class Flizpay
 	protected $plugin_name;
 
 	/**
-	 * The current version of the plugin.
-	 *
-	 * @since    1.0.0
-	 * @access   protected
-	 * @var      string    $version    The current version of the plugin.
-	 */
-	protected $version;
-
-	/**
 	 * Define the core functionality of the plugin.
 	 *
 	 * Set the plugin name and the plugin version that can be used throughout the plugin.
@@ -69,11 +60,6 @@ class Flizpay
 	 */
 	public function __construct()
 	{
-		if (defined('FLIZPAY_VERSION')) {
-			$this->version = FLIZPAY_VERSION;
-		} else {
-			$this->version = '2.1.0';
-		}
 		$this->plugin_name = 'flizpay';
 
 		$this->load_dependencies();
@@ -208,7 +194,7 @@ class Flizpay
 	private function define_admin_hooks()
 	{
 
-		$plugin_admin = new Flizpay_Admin($this->get_plugin_name(), $this->get_version());
+		$plugin_admin = new Flizpay_Admin($this->get_plugin_name(), FLIZPAY_VERSION);
 
 		$this->loader->add_action('admin_enqueue_scripts', $plugin_admin, 'enqueue_styles');
 		$this->loader->add_action('admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts');
@@ -226,7 +212,7 @@ class Flizpay
 	private function define_public_hooks()
 	{
 
-		$plugin_public = new Flizpay_Public($this->get_plugin_name(), $this->get_version());
+		$plugin_public = new Flizpay_Public($this->get_plugin_name(), FLIZPAY_VERSION);
 
 		// Hook the custom function to the 'before woocommerce init' action
 		$this->loader->add_action('before_woocommerce_init', $plugin_public, 'declare_cart_checkout_blocks_compatibility');
@@ -272,18 +258,4 @@ class Flizpay
 	{
 		return $this->loader;
 	}
-
-	/**
-	 * Retrieve the version number of the plugin.
-	 *
-	 * @since     1.0.0
-	 * @return    string    The version number of the plugin.
-	 */
-	public function get_version()
-	{
-		return $this->version;
-	}
-
-
-
 }


### PR DESCRIPTION
## Description
Please describe the changes made in this PR:

- Add support for plugin to set the current installed version on business model
- Add an upgrader action hook that runs the activator 

## Notion Ticket
[Link to Notion ticket](https://www.notion.so/Store-plugin-version-on-the-business-model-1a50aa2641a7809ba827ea15339bb44b?pvs=4)

---