### PR TITLE
feat: allow customers to choose the order status between pending and draft

### DIFF
--- a/admin/class-flizpay-admin.php
+++ b/admin/class-flizpay-admin.php
@@ -167,6 +167,19 @@ class Flizpay_Admin
 				'default' => '',
 				'desc_tip' => false,
 			),
+			'flizpay_order_status' => array(
+				'title' => $this->is_english() ? 'Pending orders status' : 'Ausstehenden Auftragsstatus',
+				'type' => 'select',
+				'description' => $this->is_english()
+					? 'When "pending" orders will show in the order search with status pending. When draft orders won\'t show in the order search, unless you access the draft orders.'
+					: 'Ausstehende Bestellungen werden in der Bestellsuche mit dem Status „Ausstehend“ angezeigt. Entwürfe werden in der Bestellsuche nicht angezeigt, es sei denn, Sie greifen auf die Bestellentwürfe zu.',
+				'default' => 'wc-pending',
+				'options' => array(
+					'wc-pending' => $this->is_english() ? 'Pending' : 'Ausstehend',
+					'wc-checkout-draft' => $this->is_english() ? 'Draft' : 'Entwurf',
+				),
+				'desc_tip' => true,
+			),
 			'flizpay_display_logo' => array(
 				'title' => 'Logo',
 				'label' => $this->is_english()

--- a/admin/class-flizpay-admin.php
+++ b/admin/class-flizpay-admin.php
@@ -167,19 +167,6 @@ class Flizpay_Admin
 				'default' => '',
 				'desc_tip' => false,
 			),
-			'flizpay_order_status' => array(
-				'title' => $this->is_english() ? 'Pending orders status' : 'Ausstehenden Auftragsstatus',
-				'type' => 'select',
-				'description' => $this->is_english()
-					? 'When "pending" orders will show in the order search with status pending. When draft orders won\'t show in the order search, unless you access the draft orders.'
-					: 'Ausstehende Bestellungen werden in der Bestellsuche mit dem Status „Ausstehend“ angezeigt. Entwürfe werden in der Bestellsuche nicht angezeigt, es sei denn, Sie greifen auf die Bestellentwürfe zu.',
-				'default' => 'wc-pending',
-				'options' => array(
-					'wc-pending' => $this->is_english() ? 'Pending' : 'Ausstehend',
-					'wc-checkout-draft' => $this->is_english() ? 'Draft' : 'Entwurf',
-				),
-				'desc_tip' => true,
-			),
 			'flizpay_display_logo' => array(
 				'title' => 'Logo',
 				'label' => $this->is_english()
@@ -207,6 +194,19 @@ class Flizpay_Admin
 				'description' => '',
 				'default' => 'yes',
 			),
+			'flizpay_order_status' => array(
+				'title' => $this->is_english() ? 'Pending Orders' : 'Ausstehende Zahlungen',
+				'type' => 'select',
+				'description' => $this->is_english()
+					? 'If someone doesn’t complete an order using FLIZpay, the order will appear in your admin system as “Payment Pending.” If you want such orders to be shown, select “Pending”. If you don’t want them to be displayed, select “Draft”'
+					: 'Falls jemand eine Bestellung mit FLIZpay nicht abgeschlossen hat, wird diese Bestellung in deinem Admin-System als „Zahlung ausstehend” angezeigt. Falls das gewünscht ist, wähle „Ausstehend”. Falls solche Bestellungen nicht angezeigt werden sollen, wähle „Entwurf”.',
+				'default' => 'wc-pending',
+				'options' => array(
+					'wc-pending' => $this->is_english() ? 'Pending' : 'Ausstehend',
+					'wc-checkout-draft' => $this->is_english() ? 'Draft' : 'Entwurf',
+				),
+				'desc_tip' => true,
+			),
 			'flizpay_enable_express_checkout' => array(
 				'title' => $this->is_english() ? 'Express checkout enabled' : 'Express-Checkout Aktiviert',
 				'type' => 'checkbox',
@@ -221,7 +221,7 @@ class Flizpay_Admin
 					'cart' => $this->is_english() ? 'Cart Page' : 'Warenkorbseite',
 				),
 				'desc_tip' => true,
-				'description' => $this->is_english() ? 'Select the pages where the express checkout button will appear.' : 'Wählen Sie die Seiten aus, auf denen die Schaltfläche für den Express-Checkout angezeigt wird.'
+				'description' => $this->is_english() ? 'Select the pages where the express checkout button will appear.' : 'Wähle die Seiten aus, auf denen die Schaltfläche für den Express-Checkout angezeigt werden soll.'
 			),
 			'flizpay_express_checkout_theme' => array(
 				'title' => $this->is_english() ? 'Express checkout button theme' : 'Design der Schaltfläche „Express-Checkout“',

--- a/admin/js/flizpay-admin.js
+++ b/admin/js/flizpay-admin.js
@@ -31,6 +31,7 @@
 Then make sure you set the shipping calculation on the Package and not on the Cart. For express checkout the cart is not required and when Flexible Shipping is not configured for Package calculation it won't be presented as a shipping option in FLIZ app.`
       : `Verwenden Sie das Plugin <a href="https://wordpress.org/plugins/flexible-shipping/">„Flexible Shipping“</a>?
 Stellen Sie dann sicher, dass Sie die Versandkostenberechnung auf dem Paket und nicht auf dem Warenkorb festlegen. Für den Express-Checkout ist der Warenkorb nicht erforderlich. Wenn „Flexible Shipping“ nicht für die Paketberechnung konfiguriert ist, wird er in der FLIZ-App nicht als Versandoption angezeigt.`;
+    const adminOptionTitle = flizpayParams.wp_locale.includes("en") ? "Admin Display Options" : "Anzeigeoptionen für Admins";
     const flexibleShippingParagraph = document.createElement("p");
     const testButton = document.createElement("div");
     const resultField = document.createElement("div");
@@ -54,16 +55,20 @@ Stellen Sie dann sicher, dass Sie die Versandkostenberechnung auf dem Paket und 
     const description = document.querySelector(
       "#connection-stablished-description"
     );
+    const orderStatus = document.querySelector("#woocommerce_flizpay_flizpay_order_status")
     const expressCheckoutButtonTheme = document.querySelector(
       "#woocommerce_flizpay_flizpay_express_checkout_theme"
     );
     const divider = document.createElement("hr");
     const divider2 = document.createElement("hr");
+    const divider3 = document.createElement("hr");
     const dividerRow = document.createElement("tr");
     const dividerRow2 = document.createElement("tr");
+    const dividerRow3 = document.createElement("tr");
     const exampleImage = document.createElement("img");
     const checkoutSectionTitle = document.createElement("h2");
     const expressCheckoutSectionTitle = document.createElement("h2");
+    const orderStatusLabel = document.createElement("h2");
     const expressCheckoutButtonLight = document.createElement("img");
     const expressCheckoutButtonDark = document.createElement("img");
     const buttonExampleLabel = document.createElement("p");
@@ -196,11 +201,16 @@ Stellen Sie dann sicher, dass Sie die Versandkostenberechnung auf dem Paket und 
       webhookAlive.setAttribute("disabled", true);
       divider.setAttribute("style", "width: 100%");
       divider2.setAttribute("style", "width: 100%");
+      divider3.setAttribute("style", "width: 100%");
       dividerRow.setAttribute(
         "style",
         "width: 80vw; display: flex; flex-wrap: wrap; justify-content: center; align-items: center; padding: 10px; text-align: center;"
       );
       dividerRow2.setAttribute(
+        "style",
+        "width: 80vw; display: flex; flex-wrap: wrap; justify-content: center; align-items: center; padding: 10px; text-align: center; gap: 20px;"
+      );
+      dividerRow3.setAttribute(
         "style",
         "width: 80vw; display: flex; flex-wrap: wrap; justify-content: center; align-items: center; padding: 10px; text-align: center; gap: 20px;"
       );
@@ -226,12 +236,19 @@ Stellen Sie dann sicher, dass Sie die Versandkostenberechnung auf dem Paket und 
       expressCheckoutButtonTheme.parentNode.append(buttonExampleLabel);
       expressCheckoutButtonTheme.parentNode.append(expressCheckoutButtonDark);
       expressCheckoutButtonTheme.parentNode.append(expressCheckoutButtonLight);
+      orderStatusLabel.innerHTML = adminOptionTitle;
+      dividerRow3.append(divider3);
+      dividerRow3.append(orderStatusLabel);
+      orderStatus.append(dividerRow2);
       document
         .querySelector("table > tbody > tr:nth-child(3)")
         .insertAdjacentElement("afterend", dividerRow);
       document
-        .querySelector("table > tbody > tr:nth-child(8)")
+        .querySelector("table > tbody > tr:nth-child(9)")
         .insertAdjacentElement("afterend", dividerRow2);
+      document
+        .querySelector("table > tbody > tr:nth-child(8)")
+        .insertAdjacentElement("afterend", dividerRow3);
 
       if (webhookAlive.checked) {
         description.setAttribute(

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -71,6 +71,7 @@ function flizpay_init_gateway_class()
             $this->flizpay_enable_express_checkout = $this->get_option('flizpay_enable_express_checkout');
             $this->flizpay_express_checkout_pages = $this->get_option('flizpay_express_checkout_pages');
             $this->flizpay_express_checkout_theme = $this->get_option('flizpay_express_checkout_theme');
+            $this->flizpay_order_status = $this->get_option('flizpay_order_status');
             // Initialize helper classes
             $this->cashback_helper = new Flizpay_Cashback_Helper($this);
             $this->webhook_helper = new Flizpay_Webhook_Helper($this);
@@ -216,6 +217,13 @@ function flizpay_init_gateway_class()
                     $this->update_option('flizpay_express_checkout_theme', $express_checkout_theme ?? 'light');
                 } else {
                     $this->update_option('flizpay_express_checkout_theme', 'light');
+                }
+
+                if (isset($_POST['woocommerce_flizpay_flizpay_order_status'])) {
+                    $flizpay_order_status = sanitize_text_field(wp_unslash($_POST['woocommerce_flizpay_flizpay_order_status']));
+                    $this->update_option('flizpay_order_status', $flizpay_order_status ?? 'wc-pending');
+                } else {
+                    $this->update_option('flizpay_order_status', 'wc-pending');
                 }
 
 
@@ -366,7 +374,7 @@ function flizpay_init_gateway_class()
         public function process_payment($order_id, $source = 'plugin')
         {
             $order = wc_get_order($order_id);
-            $order->update_status('wc-pending', 'FLIZpay Checkout initiated. Waiting for payment - ' . $source);
+            $order->update_status($this->flizpay_order_status, 'FLIZpay Checkout initiated. Waiting for payment - ' . $source);
             $order->save();
 
             $redirectUrl = $this->api_service->create_transaction($order, $source);


### PR DESCRIPTION
## Description

- Allow customers to choose the order status between pending and draft

---


## Tests

- [x] Localhost
- [x] Staging

---

## Screenshots / Videos
If there are any UI changes please add screenshots or videos:

1.
![Screenshot 2025-03-23 at 18 33 35](https://github.com/user-attachments/assets/f3f75bc7-8ced-486c-9062-86af9a7bc926)

2.
![Screenshot 2025-03-23 at 18 34 10](https://github.com/user-attachments/assets/1724b810-87cc-4d41-8dff-256a89a137b4)


## Notion Ticket
[Link to Notion ticket](https://www.notion.so/Create-config-for-order-status-1bf0aa2641a7800491d3f9a42ac016df?pvs=4)

---