### PR TITLE
fix: compatibility with legacy cashback settings

### DIFF
--- a/includes/class-flizpay-cashback-helper.php
+++ b/includes/class-flizpay-cashback-helper.php
@@ -62,7 +62,7 @@ class Flizpay_Cashback_Helper
     if (!$this->gateway->cashback)
       return null;
 
-    if (floatval($this->gateway->cashback['first_purchase_amount']) > 0) {
+    if (floatval($this->gateway->cashback['first_purchase_amount']) > 0 || floatval($this->gateway->cashback['standard_amount']) > 0) {
       return max(floatval($this->gateway->cashback['first_purchase_amount']), floatval($this->gateway->cashback['standard_amount']));
     }
   }


### PR DESCRIPTION
## Description

- Allow any of the existent cashback values on the display value of express checkout button

---


## Tests

- [x] Local wth legacy settings

---

## Notion Ticket
[Link to Notion ticket](https://www.notion.so/Bug-Cashback-is-not-showing-correctly-for-kipon-de-1c30aa2641a780b08cf6cfdbdc2fe1a4?pvs=4)

---