### PR TITLE
feat: when the language is german, use commas instead of period on decimals

### DIFF
--- a/includes/class-flizpay-cashback-helper.php
+++ b/includes/class-flizpay-cashback-helper.php
@@ -4,9 +4,12 @@ class Flizpay_Cashback_Helper
 {
   private $gateway;
 
+  private $is_german;
+
   public function __construct($gateway)
   {
     $this->gateway = $gateway;
+    $this->is_german = str_contains(get_locale(), 'de');
   }
 
   public function set_cashback_info()
@@ -22,6 +25,13 @@ class Flizpay_Cashback_Helper
       $description = __('description', 'flizpay-for-woocommerce');
       $express_checkout_title = __('express-title', 'flizpay-for-woocommerce');
     }
+
+    // Use commas for german
+    if ($this->is_cashback_available() && $this->is_german) {
+      $title = str_replace('.', ',', $title);
+      $express_checkout_title = str_replace('.', ',', $express_checkout_title);
+    }
+
     $this->gateway->title = $this->gateway->flizpay_display_headline === 'yes' ? $title : 'FLIZpay';
     $this->gateway->description = $this->gateway->flizpay_display_description === 'yes' ? $description : null;
     $this->gateway->flizpay_express_checkout_title = $express_checkout_title;
@@ -29,9 +39,10 @@ class Flizpay_Cashback_Helper
 
   public function set_title()
   {
-    $cashback_value = $this->get_display_value();
 
     if ($this->is_default_translation($this->gateway->title)) {
+      $cashback_value = str_replace('.', ',', (string) $this->get_display_value());
+
       if ($this->gateway->flizpay_display_headline === 'yes') {
         $this->gateway->title = !is_null($this->gateway->cashback)
           ? "FLIZpay - Bis zu $cashback_value% Rabatt"


### PR DESCRIPTION
## Description

- Add parse functionality to make dots become commas when shop is in german for the decimal cashback values

---


## Tests

- [x] Local

---

## Notion Ticket
[Link to Notion ticket](https://www.notion.so/Use-commas-for-decimal-cashback-values-being-displayed-in-the-plugin-when-in-German-1ce0aa2641a780debbb4d2724d1a0d13?pvs=4)

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved localization for German users by displaying cashback amounts with commas as decimal separators instead of periods.
- **Bug Fixes**
  - Ensured cashback information and titles are formatted correctly for German locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->