### PR TITLE
feat: trigger only the plugin tests on smoke tests repo

### DIFF
--- a/.github/workflows/trigger-smoke-tests.yml
+++ b/.github/workflows/trigger-smoke-tests.yml
@@ -17,4 +17,4 @@ jobs:
           curl -X POST https://api.github.com/repos/Flizpay/flizpay-smoke-tests/dispatches \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: token ${{ secrets.PAT_FOR_DISPATCH }}" \
-          -d '{"event_type": "run-smoke-tests", "client_payload": { "branch": "main" }}'
+          -d '{"event_type": "run-smoke-tests", "client_payload": { "products": "plugin" }}'


### PR DESCRIPTION
## Description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the workflow for triggering smoke tests to use a product-based parameter instead of a branch-based parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->