### PR TITLE
Fix/cost-mismatch

### DIFF
--- a/includes/class-flizpay-api-service.php
+++ b/includes/class-flizpay-api-service.php
@@ -65,44 +65,19 @@ class Flizpay_API_Service
       'lastName' => $order->get_billing_last_name()
     ];
     $body = [
-      'amount' => $order->get_total(),
+      'amount' => $order->get_subtotal(),
       'currency' => $order->get_currency(),
       'externalId' => $order->get_id(),
       'successUrl' => $order->get_checkout_order_received_url(),
       'failureUrl' => 'https://checkout.flizpay.de/failed',
       'customer' => $customer,
       'source' => $source,
-      'products' => $this->get_products($order),
       'needsShipping' => $this->needs_shipping($order)
     ];
     $client = WC_Flizpay_API::get_instance($this->api_key);
     $response = $client->dispatch('create_transaction', $body, false);
 
     return $response['redirectUrl'] ?? null;
-  }
-
-  public function get_products($order)
-  {
-    $products = array();
-
-    foreach ($order->get_items() as $item_id => $item) {
-      $product = $item->get_product();
-      if (!$product) {
-        continue;
-      }
-
-      $name = $product->get_name();
-      $amount = $item->get_quantity();
-      $price = $product->get_price();
-
-      $products[] = array(
-        'name' => $name,
-        'amount' => $amount,
-        'price' => $price,
-      );
-    }
-
-    return $products;
   }
 
   public function needs_shipping($order)

--- a/includes/class-flizpay-shipping-helper.php
+++ b/includes/class-flizpay-shipping-helper.php
@@ -110,7 +110,7 @@ class Flizpay_Shipping_Helper
         'address' => $address['address_1'],
       ],
       'contents' => $contents,
-      'contents_cost' => $order->get_total(),
+      'contents_cost' => $order->get_subtotal(),
       'applied_coupons' => $order->get_coupon_codes(),
     ];
   }

--- a/public/js/flizpay-express-checkout.js
+++ b/public/js/flizpay-express-checkout.js
@@ -198,13 +198,23 @@ jQuery(function ($) {
       const quantity = jQuery("input.qty").val() || "1";
       const productId = jQuery('[name="add-to-cart"]').val();
       const variationId = jQuery('[name="variation_id"]').val();
+      
+      // Collect variation attributes if this is a variable product
+      let variationData = {};
+      if (variationId) {
+        // Get all variation attribute fields
+        jQuery('.variations select').each(function() {
+          const attributeName = jQuery(this).attr('name');
+          variationData[attributeName] = jQuery(this).val();
+        });
+      }
 
       if (!productId) {
         alert("Product ID not found.");
         return window.location.reload();
       }
 
-      submit_order({ productId, quantity, variationId });
+      submit_order({ productId, quantity, variationId, variationData });
     }
 
     function mini_cart_submit(e) {
@@ -217,6 +227,7 @@ jQuery(function ($) {
       productId,
       quantity,
       variationId = null,
+      variationData = {},
       cart = false,
     }) {
       if (window.innerWidth < 768) {
@@ -229,6 +240,7 @@ jQuery(function ($) {
         product_id: productId,
         quantity: quantity,
         variation_id: variationId,
+        variation_data: JSON.stringify(variationData),
         nonce: flizpay_frontend.express_checkout_nonce, // For security
       };
       if (cart) data.cart = true;


### PR DESCRIPTION
## Description

- Fix the total cost mismatch error by ensuring we will be using the subtotal of the package during shipping calculation and not the total, that could lead to mismatches. 
- Fix some variations having price different from the displayed on the shop due to lack of variation attributes

---


## Tests

- [x] Local
- [x] Staging marbled works

---

## Notion Ticket
[Link to Notion ticket](https://www.notion.so/Sentry-Error-Total-cost-mismatch-x-2-1d70aa2641a780abb77af30bb6447196?pvs=4)

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced express checkout to support detailed product variation attributes when adding items to the cart.

- **Bug Fixes**
  - Adjusted transaction and shipping calculations to use order subtotal instead of total, ensuring more accurate cost handling.

- **Refactor**
  - Removed the products field from transaction requests and eliminated related internal logic for product detail extraction.

- **Style**
  - Improved data collection for product variations in the checkout interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->