### PR TITLE
feat: explicitly add FLIZ as payment method

### DIFF
--- a/admin/class-flizpay-admin.php
+++ b/admin/class-flizpay-admin.php
@@ -202,8 +202,8 @@ class Flizpay_Admin
 					: 'Falls jemand eine Bestellung mit FLIZpay nicht abgeschlossen hat, wird diese Bestellung in deinem Admin-System als „Zahlung ausstehend” angezeigt. Falls das gewünscht ist, wähle „Ausstehend”. Falls solche Bestellungen nicht angezeigt werden sollen, wähle „Entwurf”.',
 				'default' => 'wc-pending',
 				'options' => array(
-					'pending' => $this->is_english() ? 'Pending' : 'Ausstehend',
-					'checkout-draft' => $this->is_english() ? 'Draft' : 'Entwurf',
+					'wc-pending' => $this->is_english() ? 'Pending' : 'Ausstehend',
+					'wc-checkout-draft' => $this->is_english() ? 'Draft' : 'Entwurf',
 				),
 				'desc_tip' => true,
 			),

--- a/admin/class-flizpay-admin.php
+++ b/admin/class-flizpay-admin.php
@@ -202,8 +202,8 @@ class Flizpay_Admin
 					: 'Falls jemand eine Bestellung mit FLIZpay nicht abgeschlossen hat, wird diese Bestellung in deinem Admin-System als „Zahlung ausstehend” angezeigt. Falls das gewünscht ist, wähle „Ausstehend”. Falls solche Bestellungen nicht angezeigt werden sollen, wähle „Entwurf”.',
 				'default' => 'wc-pending',
 				'options' => array(
-					'wc-pending' => $this->is_english() ? 'Pending' : 'Ausstehend',
-					'wc-checkout-draft' => $this->is_english() ? 'Draft' : 'Entwurf',
+					'pending' => $this->is_english() ? 'Pending' : 'Ausstehend',
+					'checkout-draft' => $this->is_english() ? 'Draft' : 'Entwurf',
 				),
 				'desc_tip' => true,
 			),

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -104,6 +104,9 @@ function flizpay_init_gateway_class()
             // Express checkout handler
             add_action("wp_ajax_flizpay_express_checkout", array($this, "flizpay_express_checkout"));
             add_action("wp_ajax_nopriv_flizpay_express_checkout", array($this, "flizpay_express_checkout"));
+
+            // Order status filtering
+            add_filter('woocommerce_reports_order_statuses', array($this, 'add_custom_order_statuses_to_reports'), 10, 1);
         }
 
         /**
@@ -447,6 +450,10 @@ function flizpay_init_gateway_class()
             $order_id = wc_create_order();
             $order = wc_get_order($order_id);
 
+            // Set payment method explicitly for express checkout orders
+            $order->set_payment_method('flizpay');
+            $order->set_payment_method_title('FLIZpay');
+
             foreach (WC()->cart->get_cart() as $cart_item_key => $cart_item) {
                 $item = new WC_Order_Item_Product();
 
@@ -477,6 +484,23 @@ function flizpay_init_gateway_class()
                 $this->process_payment($order->get_id(), 'express_checkout')
             ));
             die();
+        }
+
+        /**
+         * Add custom FLIZ order statuses to WooCommerce reports
+         * This ensures orders with custom statuses appear in reports
+         * 
+         * @param array $statuses
+         * @return array
+         * 
+         * @since 2.4.2
+         */
+        public function add_custom_order_statuses_to_reports($statuses)
+        {
+            // Add checkout-draft status to reports for FLIZ orders
+            $statuses[] = 'checkout-draft';
+            $statuses[] = 'wc-checkout-draft';
+            return $statuses;
         }
     }
 }

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -104,9 +104,6 @@ function flizpay_init_gateway_class()
             // Express checkout handler
             add_action("wp_ajax_flizpay_express_checkout", array($this, "flizpay_express_checkout"));
             add_action("wp_ajax_nopriv_flizpay_express_checkout", array($this, "flizpay_express_checkout"));
-
-            // Order status filtering
-            add_filter('woocommerce_reports_order_statuses', array($this, 'add_custom_order_statuses_to_reports'), 10, 1);
         }
 
         /**
@@ -484,23 +481,6 @@ function flizpay_init_gateway_class()
                 $this->process_payment($order->get_id(), 'express_checkout')
             ));
             die();
-        }
-
-        /**
-         * Add custom FLIZ order statuses to WooCommerce reports
-         * This ensures orders with custom statuses appear in reports
-         * 
-         * @param array $statuses
-         * @return array
-         * 
-         * @since 2.4.2
-         */
-        public function add_custom_order_statuses_to_reports($statuses)
-        {
-            // Add checkout-draft status to reports for FLIZ orders
-            $statuses[] = 'checkout-draft';
-            $statuses[] = 'wc-checkout-draft';
-            return $statuses;
         }
     }
 }

--- a/includes/class-flizpay-webhook-helper.php
+++ b/includes/class-flizpay-webhook-helper.php
@@ -65,6 +65,12 @@ class Flizpay_Webhook_Helper
       wp_send_json_error('Order not found', 404);
     }
 
+    // Ensure payment method is set correctly regardless of status
+    if ($order->get_payment_method() !== 'flizpay') {
+      $order->set_payment_method('flizpay');
+      $order->set_payment_method_title('FLIZpay');
+    }
+
     if ($status === 'completed') {
       $this->complete_order($order, $data);
     }
@@ -105,6 +111,10 @@ class Flizpay_Webhook_Helper
 
   private function complete_order($order, $data)
   {
+    // Explicitly set the payment method before completing payment
+    $order->set_payment_method('flizpay');
+    $order->set_payment_method_title('FLIZpay');
+
     $order->payment_complete($data['transactionId']);
     $fliz_discount = (float) $data['originalAmount'] - (float) $data['amount'];
     $cashback_value = (float) ($fliz_discount * 100) / $data['originalAmount'];


### PR DESCRIPTION
## Description

- Explicitly add flizpay as the payment method for the order and add our custom statuses to order reports so order can be shown on the dashboard

---


## Tests

- [x] Local
- [x] Flizpay.store prod


## Notion Ticket
[Link to Notion ticket](https://www.notion.so/Fix-completed-orders-not-being-displayed-in-admin-panel-and-orders-not-having-fliz-as-payment-metho-1e90aa2641a780a38a70c15bf52776a3?pvs=4)

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Orders with custom statuses related to FLIZpay are now included in WooCommerce reports.
- **Bug Fixes**
  - Ensured that orders created via express checkout and webhooks are consistently marked with the correct FLIZpay payment method and title.
- **Chores**
  - Updated option keys for order status selection in admin settings to improve consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->