### PR TITLE
hotfix: use get total in orders instead of subtotal

### DIFF
--- a/includes/class-flizpay-api-service.php
+++ b/includes/class-flizpay-api-service.php
@@ -65,7 +65,7 @@ class Flizpay_API_Service
       'lastName' => $order->get_billing_last_name()
     ];
     $body = [
-      'amount' => $order->get_subtotal(),
+      'amount' => $order->get_total(),
       'currency' => $order->get_currency(),
       'externalId' => $order->get_id(),
       'successUrl' => $order->get_checkout_order_received_url(),

--- a/includes/class-flizpay-shipping-helper.php
+++ b/includes/class-flizpay-shipping-helper.php
@@ -110,7 +110,7 @@ class Flizpay_Shipping_Helper
         'address' => $address['address_1'],
       ],
       'contents' => $contents,
-      'contents_cost' => $order->get_subtotal(),
+      'contents_cost' => $order->get_total(),
       'applied_coupons' => $order->get_coupon_codes(),
     ];
   }


### PR DESCRIPTION
## Description

- During cost mismatch fix of variations we changed this to subtotal. We should only use order total when obtaining the order cost

---


## Tests

- [x] Local


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated transaction and shipping calculations to use the order's total amount instead of the subtotal, ensuring all charges, discounts, and fees are accurately reflected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->