### PR TITLE
fix: possible fix for shipping cost not appearing in our total amount

### DIFF
--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -475,7 +475,7 @@ function flizpay_init_gateway_class()
             foreach ($order->get_items('shipping') as $item_id => $shipping_item) {
                 $order->remove_item($item_id);
             }
-            $order->calculate_totals();
+            $order->calculate_totals(true);
             $order->save();
 
             echo esc_html(wp_send_json_success(

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -378,6 +378,7 @@ function flizpay_init_gateway_class()
         public function process_payment($order_id, $source = 'plugin')
         {
             $order = wc_get_order($order_id);
+            $order->calculate_totals(true);
             $order->update_status($this->flizpay_order_status, 'FLIZpay Checkout initiated. Waiting for payment - ' . $source);
             $order->save();
 

--- a/includes/class-flizpay-shipping-helper.php
+++ b/includes/class-flizpay-shipping-helper.php
@@ -160,7 +160,7 @@ class Flizpay_Shipping_Helper
     $this->remove_existing_shipping_items($order);
     $this->add_selected_shipping_method($order, $selected_method);
 
-    $order->calculate_totals();
+    $order->calculate_totals(true);
     $order->save();
 
     return $order->get_total();

--- a/includes/class-flizpay-webhook-helper.php
+++ b/includes/class-flizpay-webhook-helper.php
@@ -152,7 +152,7 @@ class Flizpay_Webhook_Helper
     }
 
     $order->calculate_taxes();
-    $order->calculate_totals();
+    $order->calculate_totals(true);
     $order->set_total($data['amount']);
     $order->add_order_note('FLIZ Cashback Applied: ' . $currency . sanitize_text_field($fliz_discount));
     WC()->cart->empty_cart();


### PR DESCRIPTION
## Description

- Sometimes shipping fees do not appear in total amount. We try now to recalculate all order costs before creating transaction 

---


## Tests

- [x] Paid on flizpay.store


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved order processing to ensure order totals are accurately recalculated before payment completion and after applying discounts or shipping changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->