### PR TITLE
fix: bug where we set shipping to false if any item does not need

### DIFF
--- a/includes/class-flizpay-api-service.php
+++ b/includes/class-flizpay-api-service.php
@@ -88,8 +88,8 @@ class Flizpay_API_Service
         continue;
       }
 
-      if (!$product->needs_shipping())
-        return false;
+      if ($product->needs_shipping())
+        return true;
     }
 
     return true;


### PR DESCRIPTION
## Description

- Fixed bug where we where setting shipping to false if any product did not need shipping. This logic is incorrect, we need to set shipping to true if any product requires shipping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the logic for determining if an order requires shipping, ensuring shipping is needed if any product in the order requires it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->