### PR TITLE
fix: nonce was not being verified on test_gateway_connection

### DIFF
--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -157,7 +157,9 @@ function flizpay_init_gateway_class()
          */
         public function test_gateway_connection()
         {
-            wp_verify_nonce( $_REQUEST['_wpnonce'], 'woocommerce-settings' );
+            if ( ! wp_verify_nonce( $_REQUEST['_wpnonce'], 'woocommerce-settings' ) ) {
+                wp_die( 'Security check failed' );
+            }
             if (isset($_POST['woocommerce_flizpay_flizpay_api_key'])) {
                 $api_key = sanitize_text_field(wp_unslash($_POST['woocommerce_flizpay_flizpay_api_key']));
 

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -157,7 +157,7 @@ function flizpay_init_gateway_class()
          */
         public function test_gateway_connection()
         {
-            wp_verify_nonce('_wpnonce');
+            wp_verify_nonce( $_REQUEST['_wpnonce'], 'woocommerce-settings' );
             if (isset($_POST['woocommerce_flizpay_flizpay_api_key'])) {
                 $api_key = sanitize_text_field(wp_unslash($_POST['woocommerce_flizpay_flizpay_api_key']));
 


### PR DESCRIPTION
## Description

- Nonce was not being verified, we where just passing a string, opening us up to CSRF attacks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved security for admin settings by correctly verifying nonces during gateway connection tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->