### PR TITLE
fix: possible fix for webhook rewrite not being set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .vscode
+.stubs/

--- a/includes/class-flizpay-activator.php
+++ b/includes/class-flizpay-activator.php
@@ -32,6 +32,9 @@ class Flizpay_Activator
     {
         require_once('class-flizpay-api.php');
 
+        // Force rewrite rules flush on activation
+        delete_option('flizpay_rewrite_rules_flushed');
+
         $flizpay_settings = get_option('woocommerce_flizpay_settings');
 
         if (!$flizpay_settings)

--- a/includes/class-flizpay-api-service.php
+++ b/includes/class-flizpay-api-service.php
@@ -20,7 +20,7 @@ class Flizpay_API_Service
 
   public function generate_webhook_url()
   {
-    $webhookUrl = home_url('/flizpay-webhook?flizpay-webhook=1&source=woocommerce');
+    $webhookUrl = home_url('/flizpay-webhook/', 'https');
 
     if (str_contains($webhookUrl, 'https://') === false && str_contains($webhookUrl, 'http://') === false) {
       $webhookUrl = "https://" . $webhookUrl;

--- a/includes/class-flizpay-webhook-helper.php
+++ b/includes/class-flizpay-webhook-helper.php
@@ -36,8 +36,8 @@ class Flizpay_Webhook_Helper
     // Check if our rewrite rule exists in WordPress rewrite rules
     global $wp_rewrite;
     $current_rules = $wp_rewrite->wp_rewrite_rules();
-    
-    return !isset($current_rules['^flizpay-webhook/?']);
+
+    return !is_array($current_rules) || !isset($current_rules['^flizpay-webhook/?']);
   }
 
   public function handle_webhook_request()

--- a/includes/class-flizpay-webhook-helper.php
+++ b/includes/class-flizpay-webhook-helper.php
@@ -14,9 +14,30 @@ class Flizpay_Webhook_Helper
     add_rewrite_tag('%flizpay-webhook%', '([^&]+)');
     add_rewrite_rule('^flizpay-webhook/?', 'index.php?flizpay-webhook=1&source=woocommerce', 'top');
 
-    if (empty($this->gateway->get_option('flizpay_webhook_key'))) {
+    // Check if rewrite rules need to be flushed
+    if ($this->should_flush_rewrite_rules()) {
       flush_rewrite_rules();
+      update_option('flizpay_rewrite_rules_flushed', true);
     }
+  }
+
+  private function should_flush_rewrite_rules()
+  {
+    // Always flush if rules haven't been flushed before
+    if (!get_option('flizpay_rewrite_rules_flushed')) {
+      return true;
+    }
+
+    // Flush if webhook key is empty
+    if (empty($this->gateway->get_option('flizpay_webhook_key'))) {
+      return true;
+    }
+
+    // Check if our rewrite rule exists in WordPress rewrite rules
+    global $wp_rewrite;
+    $current_rules = $wp_rewrite->wp_rewrite_rules();
+    
+    return !isset($current_rules['^flizpay-webhook/?']);
   }
 
   public function handle_webhook_request()


### PR DESCRIPTION
## Description

Possible fix for webhook rewrite not being set

- manually update custom option if flush_rewrite_rules() was called
- flush if webhook key is empty
- flush is no custom option found
- flush if flizpay rewrite rule does not exist in WordPress rewrite rules
- flush rewrite rules on each plugin activation

Use clean webhook url (no search parameters):

  1. WordPress URL Processing
  - External call: /flizpay-webhook?flizpay-webhook=1
  - WordPress thinks: "Find a page/post with slug 'flizpay-webhook'"
  - Result: 404 if no such page exists
  vs
  - External call: /flizpay-webhook/
  - WordPress thinks: "Check rewrite rules first"
  - Rewrite rule: ^flizpay-webhook/? → index.php?flizpay-webhook=1
  - Result: Properly routed to your handler

  3. Permalink Conflicts
  - With pretty permalinks enabled (/category/post-name/), WordPress processes URLs differently
  - Query parameters can get stripped during canonical redirects
  - Clean URLs work with ALL permalink structures

  4. External System Compatibility
  - Some webhook callers URL-encode query parameters: ? becomes %3F, & becomes %26
  - CDNs and proxies may cache differently based on query strings
  - Some systems strip query parameters for "security"

  5. WordPress Rewrite System Design
  WordPress rewrite system is designed for:
  - External URLs: Clean, SEO-friendly (/flizpay-webhook/)
  - Internal processing: Query parameters (?flizpay-webhook=1)

  The flow:
  1. External service calls: POST /flizpay-webhook/
  2. WordPress rewrite converts to: index.php?flizpay-webhook=1&source=woocommerce
  3. Handler detects: isset($wp->query_vars['flizpay-webhook'])
  
  -----
  Tests
  
  - [x] Tested locally with Revolut (order marked as completed in Woocommerce orders section)
  

![Screenshot 2025-05-28 at 15 32 45](https://github.com/user-attachments/assets/7bb772ec-e699-4451-ba8e-b54a897abfe2)



---

## Notion Ticket
[NOTION TICKET](https://www.notion.so/Plugin-tasks-1f00aa2641a780f88752e17f523b64ab?pvs=4)

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of webhook endpoint registration by enhancing how WordPress rewrite rules are managed, ensuring smoother setup and fewer issues with webhook connectivity.
  - Updated webhook URL generation to enforce secure HTTPS connections for improved security.
- **Chores**
  - Added cleanup of rewrite rules flush flag during plugin activation to ensure proper initialization.
  - Updated ignored files configuration to exclude additional development artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->