### PR TITLE
feat: add https to webhook urls

### DIFF
--- a/includes/class-flizpay-api-service.php
+++ b/includes/class-flizpay-api-service.php
@@ -22,7 +22,7 @@ class Flizpay_API_Service
   {
     $webhookUrl = home_url('/flizpay-webhook?flizpay-webhook=1&source=woocommerce');
 
-    if (str_contains($webhookUrl, 'https://') === false) {
+    if (str_contains($webhookUrl, 'https://') === false && str_contains($webhookUrl, 'http://') === false) {
       $webhookUrl = "https://" . $webhookUrl;
     }
 

--- a/includes/class-flizpay-api-service.php
+++ b/includes/class-flizpay-api-service.php
@@ -22,6 +22,10 @@ class Flizpay_API_Service
   {
     $webhookUrl = home_url('/flizpay-webhook?flizpay-webhook=1&source=woocommerce');
 
+    if (str_contains($webhookUrl, 'https://') === false) {
+      $webhookUrl = "https://" . $webhookUrl;
+    }
+
     $client = WC_Flizpay_API::get_instance($this->api_key);
 
     $response = $client->dispatch('edit_business', array('webhookUrl' => $webhookUrl), false);


### PR DESCRIPTION
## Description

- Axios request won't work if the protocol is missing on the url

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that generated webhook URLs always use the HTTPS scheme for improved security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->