### PR TITLE
release: bump to version 2.4.5

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,8 @@
 == FLIZpay for WooCommerce Changelog ==
 
+2025-27-05 - version 2.4.5
+* Fixed - Webhook URL missing HTTPS protocol
+
 2025-19-05 - version 2.4.4
 * Added - Plugin version to frontend
 

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: Flizpay
 Tags: kostenlos, payments, Zahlung, cashback, no-fee
 Requires at least: 4.4
 Tested up to: 6.7
-Stable tag: 2.4.4
+Stable tag: 2.4.5
 Requires PHP: 7.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.txt
@@ -172,7 +172,13 @@ Der erste Schritt, um FLIZpay in deinem Checkout zu installieren, ist die Erstel
 - v2.4.4
   - ADDED - Plugin version to frontend
 
+- v2.4.5
+  - FIXED - Webhook URL missing HTTPS protocol
+
 == Upgrade Notice ==
+
+= 2.4.5 =
+* Fixed - Webhook URL missing HTTPS protocol
 
 = 2.4.4 =
 * Added - Plugin version to frontend

--- a/flizpay.php
+++ b/flizpay.php
@@ -16,7 +16,7 @@
  * Plugin Name:       FLIZpay Gateway für WooCommerce
  * Plugin URI:        https://www.flizpay.de/companies
  * Description:       FLIZpay: 100% free!
- * Version:           2.4.4
+ * Version:           2.4.5
  * Author:            FLIZpay
  * Author URI:        https://www.flizpay.de/companies
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if (!defined('WPINC')) {
  * Currently plugin version.
  * Start at version 1.0.0 and use SemVer - https://semver.org
  */
-define('FLIZPAY_VERSION', '2.4.4');
+define('FLIZPAY_VERSION', '2.4.5');
 
 function flizpay_check_dependencies()
 {

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -1,6 +1,6 @@
 <?php
 if (!defined('FLIZPAY_VERSION')) {
-    define('FLIZPAY_VERSION', '2.4.4');
+    define('FLIZPAY_VERSION', '2.4.5');
 }
 
 /**
@@ -157,8 +157,8 @@ function flizpay_init_gateway_class()
          */
         public function test_gateway_connection()
         {
-            if ( ! wp_verify_nonce( $_REQUEST['_wpnonce'], 'woocommerce-settings' ) ) {
-                wp_die( 'Security check failed' );
+            if (!wp_verify_nonce($_REQUEST['_wpnonce'], 'woocommerce-settings')) {
+                wp_die('Security check failed');
             }
             if (isset($_POST['woocommerce_flizpay_flizpay_api_key'])) {
                 $api_key = sanitize_text_field(wp_unslash($_POST['woocommerce_flizpay_flizpay_api_key']));

--- a/languages/flizpay-for-woocommerce-de_DE.po
+++ b/languages/flizpay-for-woocommerce-de_DE.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: FlizPay 2.4.4\n"
+"Project-Id-Version: FlizPay 2.4.5\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-07-30 10:00+0000\n"
 "PO-Revision-Date: 2024-07-30 10:00+0000\n"

--- a/languages/flizpay-for-woocommerce-en_GB.po
+++ b/languages/flizpay-for-woocommerce-en_GB.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: FlizPay 2.4.4\n"
+"Project-Id-Version: FlizPay 2.4.5\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-07-30 10:00+0000\n"
 "PO-Revision-Date: 2024-07-30 10:00+0000\n"

--- a/languages/flizpay-for-woocommerce-en_US.po
+++ b/languages/flizpay-for-woocommerce-en_US.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: FlizPay 2.4.4\n"
+"Project-Id-Version: FlizPay 2.4.5\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-07-30 10:00+0000\n"
 "PO-Revision-Date: 2024-07-30 10:00+0000\n"


### PR DESCRIPTION
Release v2.4.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where the webhook URL was missing the HTTPS protocol.

- **Documentation**
  - Updated changelog and upgrade notice to reflect version 2.4.5 and the webhook URL fix.
  - Updated stable tag and version numbers in documentation and translation files to 2.4.5.

- **Chores**
  - Incremented plugin version to 2.4.5 across all relevant files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->