### PR TITLE
fix: needs shipping method always return a boolean

### DIFF
--- a/includes/class-flizpay-api-service.php
+++ b/includes/class-flizpay-api-service.php
@@ -84,18 +84,15 @@ class Flizpay_API_Service
     return $response['redirectUrl'] ?? null;
   }
 
-  public function needs_shipping($order)
+  public function needs_shipping($order): bool
   {
     foreach ($order->get_items() as $item_id => $item) {
       $product = $item->get_product();
-      if (!$product) {
-        continue;
+      if ($product && $product->needs_shipping()) {
+        return true;      // at least one shippable item found
       }
-
-      if ($product->needs_shipping())
-        return true;
     }
 
-    return true;
+    return false; // no shippable items found
   }
 }


### PR DESCRIPTION
## Description

Needs shipping method always return a boolean

- Returns false when orders in the cart all virtual
- Returns true when orders in a cart mixed (virtual and shippable)

---


## Tests

- [x] Payed for non-shippable product (payer-web/Sparkasse)
- [x] Payed shippable product (payer-web/Revolut)

---


## Notion Ticket
[NOTION TICKET](https://www.notion.so/Bug-when-paying-non-shippable-product-on-Woocommerce-frontend-forces-to-select-shippping-2290aa2641a780fbbf61f18aa2bcba1b?source=copy_link)

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of shipping requirement checks for orders, ensuring correct handling when no shippable items are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->