### PR TITLE
fix: cashback messages in German

### DIFF
--- a/languages/flizpay-for-woocommerce-de_DE.po
+++ b/languages/flizpay-for-woocommerce-de_DE.po
@@ -25,7 +25,7 @@ msgstr "FLIZpay - Bis zu %s%% Rabatt"
 
 #: includes/class-flizpay-gateway.php:106
 msgid "cashback-description-both"
-msgstr "Sichere Zahlungen in direkter Zusammenarbeit mit deiner Bank. Nach deiner ersten FLIZ-Zahlung bei %s gibt es weiterhin %s%% Sofort-Cashback."
+msgstr "Sichere Zahlungen in direkter Zusammenarbeit mit deiner Bank. Ab der zweiten Zahlung bei %s gibt es dauerhaft %s%% Rabatt."
 
 #: includes/class-flizpay-gateway.php:108
 msgid "cashback-description-standard"


### PR DESCRIPTION
## Description
Update German cashback description to clarify discount applies from the second payment onwards instead of after the first payment.



## Notion Ticket
[Link to Notion ticket](Paste Notion ticket link here)
https://www.notion.so/Change-wording-in-checkout-21e0aa2641a780c8864de0390d14c9af?source=copy_link

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the German translation for the cashback description to clarify that a permanent discount is applied starting from the second payment at the merchant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->