### PR TITLE
Revert "release: v2.4.8"

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,11 +1,5 @@
 == FLIZpay for WooCommerce Changelog ==
 
-2025-18-07 - version 2.4.8
-* Fixed - German localization: Corrected the cashback description and payment confirmation message,
-* Fixed - Shipping API: Ensured needs_shipping_method now always returns a boolean.
-* Added - Sentry integration: Enabled error tracking for both checkout and product flows.
-* Added - Admin option: Introduced a new “Error Reporting” toggle in the admin panel to turn Sentry on or off.
-
 2025-24-06 - version 2.4.7
 * Fixed - Total cost mismatch issue. Calculations now happen only in woocommerce
 

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: Flizpay
 Tags: kostenlos, payments, Zahlung, cashback, no-fee
 Requires at least: 4.4
 Tested up to: 6.7
-Stable tag: 2.4.8
+Stable tag: 2.4.7
 Requires PHP: 7.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.txt
@@ -198,19 +198,7 @@ Der erste Schritt, um FLIZpay in deinem Checkout zu installieren, ist die Erstel
 - v2.4.7
   - FIXED - Total cost calculation for express checkout now happens only in WooCommerce, preventing mismatches
 
-- v2.4.8
-  - FIXED - German localization: Corrected the cashback description and payment confirmation message,
-  - FIXED - Shipping API: Ensured needs_shipping_method now always returns a boolean.
-  - ADDED - Sentry integration: Enabled error tracking for both checkout and product flows.
-  - ADDED - Admin option: Introduced a new “Error Reporting” toggle in the admin panel to turn Sentry on or off.
-
 == Upgrade Notice ==
-
-= 2.4.8 =
-* FIXED - German localization: Corrected the cashback description and payment confirmation message,
-* FIXED - Shipping API: Ensured needs_shipping_method now always returns a boolean.
-* ADDED - Sentry integration: Enabled error tracking for both checkout and product flows.
-* ADDED - Admin option: Introduced a new “Error Reporting” toggle in the admin panel to turn Sentry on or off.
 
 = 2.4.7 =
 * FIXED - Total cost calculation for express checkout now happens only in WooCommerce, preventing mismatches

--- a/flizpay.php
+++ b/flizpay.php
@@ -16,7 +16,7 @@
  * Plugin Name:       FLIZpay Gateway für WooCommerce
  * Plugin URI:        https://www.flizpay.de/companies
  * Description:       FLIZpay: 100% free!
- * Version:           2.4.8
+ * Version:           2.4.7
  * Author:            FLIZpay
  * Author URI:        https://www.flizpay.de/companies
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if (!defined('WPINC')) {
  * Currently plugin version.
  * Start at version 1.0.0 and use SemVer - https://semver.org
  */
-define('FLIZPAY_VERSION', '2.4.8');
+define('FLIZPAY_VERSION', '2.4.7');
 
 /**
  * Load Composer autoloader

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -1,6 +1,6 @@
 <?php
 if (!defined('FLIZPAY_VERSION')) {
-    define('FLIZPAY_VERSION', '2.4.8');
+    define('FLIZPAY_VERSION', '2.4.7');
 }
 
 /**

--- a/languages/flizpay-for-woocommerce-de_DE.po
+++ b/languages/flizpay-for-woocommerce-de_DE.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: FlizPay 2.4.8\n"
+"Project-Id-Version: FlizPay 2.4.7\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-07-30 10:00+0000\n"
 "PO-Revision-Date: 2024-07-30 10:00+0000\n"

--- a/languages/flizpay-for-woocommerce-en_GB.po
+++ b/languages/flizpay-for-woocommerce-en_GB.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: FlizPay 2.4.8\n"
+"Project-Id-Version: FlizPay 2.4.7\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-07-30 10:00+0000\n"
 "PO-Revision-Date: 2024-07-30 10:00+0000\n"

--- a/languages/flizpay-for-woocommerce-en_US.po
+++ b/languages/flizpay-for-woocommerce-en_US.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: FlizPay 2.4.8\n"
+"Project-Id-Version: FlizPay 2.4.7\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-07-30 10:00+0000\n"
 "PO-Revision-Date: 2024-07-30 10:00+0000\n"


### PR DESCRIPTION
Reverts Flizpay/flizpay-for-woocommerce#153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * Reverted version number from 2.4.8 to 2.4.7 across plugin files and documentation.
  * Removed all documentation and changelog entries related to version 2.4.8.
  * Updated translation files to reflect the previous version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->