### PR TITLE
fix: sentry not loading correctly for some stores

### DIFF
--- a/flizpay.php
+++ b/flizpay.php
@@ -38,9 +38,9 @@ if (!defined('WPINC')) {
 define('FLIZPAY_VERSION', '2.4.10');
 
 /**
- * Load Composer autoloader
+ * Load Composer autoloader only if PHP version meets requirements
  */
-if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+if (file_exists(__DIR__ . '/vendor/autoload.php') && version_compare(PHP_VERSION, '8.2.0', '>=')) {
 	require_once __DIR__ . '/vendor/autoload.php';
 }
 
@@ -48,6 +48,17 @@ if (file_exists(__DIR__ . '/vendor/autoload.php')) {
  * Initialize Sentry error tracking after WordPress is loaded
  */
 function flizpay_init_sentry() {
+	// Check PHP version requirement (8.2.0 or higher)
+	if (version_compare(PHP_VERSION, '8.2.0', '<')) {
+		// PHP version is too low, skip Sentry initialization
+		return;
+	}
+
+	// Check if Sentry init function exists (autoloader was loaded successfully)
+	if (!function_exists('\Sentry\init')) {
+		return;
+	}
+
 	/**
 	 * Check for user consent for using telemetry (Sentry)
 	 * This is used to collect anonymous usage and error data.

--- a/flizpay.php
+++ b/flizpay.php
@@ -155,6 +155,30 @@ function flizpay_init_sentry() {
 // Hook Sentry initialization to plugins_loaded to ensure WordPress is ready
 add_action('plugins_loaded', 'flizpay_init_sentry', 1);
 
+/**
+ * Safe wrapper for Sentry\withScope
+ * Only executes if Sentry is available
+ */
+function flizpay_sentry_with_scope($callback) {
+	if (function_exists('\Sentry\withScope')) {
+		return \Sentry\withScope($callback);
+	}
+	// If Sentry is not available, just return null
+	return null;
+}
+
+/**
+ * Safe wrapper for Sentry\captureException
+ * Only executes if Sentry is available
+ */
+function flizpay_sentry_capture_exception($exception) {
+	if (function_exists('\Sentry\captureException')) {
+		return \Sentry\captureException($exception);
+	}
+	// If Sentry is not available, just return null
+	return null;
+}
+
 function flizpay_check_dependencies()
 {
 	// Check if WooCommerce is active

--- a/flizpay.php
+++ b/flizpay.php
@@ -45,139 +45,14 @@ if (file_exists(__DIR__ . '/vendor/autoload.php') && version_compare(PHP_VERSION
 }
 
 /**
- * Initialize Sentry error tracking after WordPress is loaded
+ * Load Sentry helper class
  */
-function flizpay_init_sentry() {
-	// Check PHP version requirement (8.2.0 or higher)
-	if (version_compare(PHP_VERSION, '8.2.0', '<')) {
-		// PHP version is too low, skip Sentry initialization
-		return;
-	}
-
-	// Check if Sentry init function exists (autoloader was loaded successfully)
-	if (!function_exists('\Sentry\init')) {
-		return;
-	}
-
-	/**
-	 * Check for user consent for using telemetry (Sentry)
-	 * This is used to collect anonymous usage and error data.
-	 * If the user has not made a choice yet, we will save the default setting
-	 * to 'yes' so that we can collect data.
-	 * If the user has made a choice, we will respect that choice.
-	 * The setting is stored in the WooCommerce settings array.
-	 */
-	$flizpay_settings = get_option('woocommerce_flizpay_settings', []);
-
-	if (!isset($flizpay_settings['flizpay_sentry_enabled'])) {
-		// If the setting does not exist, set it to 'yes' by default
-		$flizpay_settings['flizpay_sentry_enabled'] = 'yes';
-		update_option('woocommerce_flizpay_settings', $flizpay_settings);
-	}
-
-	/**
-	 * Sentry error tracking integration.
-	 * This integration is used to capture errors and performance data.
-	 */
-	\Sentry\init([
-		'dsn' => 'https://d2941234a076cdd12190f707115ca5c9@o4507078336053248.ingest.de.sentry.io/4509638952419408',
-
-		// Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-		'traces_sample_rate' => 1,
-
-		// Decide whether to send certain events to Sentry or disable logging at all.
-		'before_send' => static function (\Sentry\Event $event): ?\Sentry\Event {
-			//  --------------------------------------------
-			//  1) global switch living in the options table
-			//  Check in WooCommerce settings array
-			//  --------------------------------------------
-			$flizpay_settings = get_option('woocommerce_flizpay_settings', []);
-			$disabled = ($flizpay_settings['flizpay_sentry_enabled'] ?? '') !== 'yes';
-			if ($disabled) {
-				return null;
-			}
-
-
-			//  --------------------------------------------
-			//  2) Per-event ignore flag
-			//  --------------------------------------------
-			$should_ignore_event = ($event->getExtra()['ignore_for_sentry'] ?? 'false') === 'true';
-			if ($should_ignore_event) {
-				return null;
-			}
-
-			//  --------------------------------------------
-			//  3) Send only errors which originated from FLIZpay plugin
-			//  --------------------------------------------
-			$pluginPath = plugin_dir_path(__FILE__);
-
-
-			//  --------------------------------------------
-			// 	3.1) Look for a plugin frame in exceptions…
-			//  --------------------------------------------
-			foreach ($event->getExceptions() ?? [] as $exc) {
-				if (! $stack = $exc->getStacktrace()) {
-					continue;
-				}
-				foreach ($stack->getFrames() as $frame) {
-					if (
-						($file = $frame->getFile())
-						&& strpos($file, $pluginPath) === 0
-					) {
-						// Found one: send it
-						return $event;
-					}
-				}
-			}
-
-			//  --------------------------------------------
-			// 	3.2) …and for "message" events (no exceptions), inspect the event's own stacktrace
-			//  --------------------------------------------
-			if ($stack = $event->getStacktrace()) {
-				foreach ($stack->getFrames() as $frame) {
-					if (
-						($file = $frame->getFile())
-						&& strpos($file, $pluginPath) === 0
-					) {
-						return $event;
-					}
-				}
-			}
-
-			//  --------------------------------------------
-			//  No frames under our plugin dir → drop the event
-			//  --------------------------------------------
-			return null;
-		}
-	]);
-}
-
-// Hook Sentry initialization to plugins_loaded to ensure WordPress is ready
-add_action('plugins_loaded', 'flizpay_init_sentry', 1);
+require_once plugin_dir_path(__FILE__) . 'includes/class-flizpay-sentry.php';
 
 /**
- * Safe wrapper for Sentry\withScope
- * Only executes if Sentry is available
+ * Initialize Sentry after WordPress is loaded
  */
-function flizpay_sentry_with_scope($callback) {
-	if (function_exists('\Sentry\withScope')) {
-		return \Sentry\withScope($callback);
-	}
-	// If Sentry is not available, just return null
-	return null;
-}
-
-/**
- * Safe wrapper for Sentry\captureException
- * Only executes if Sentry is available
- */
-function flizpay_sentry_capture_exception($exception) {
-	if (function_exists('\Sentry\captureException')) {
-		return \Sentry\captureException($exception);
-	}
-	// If Sentry is not available, just return null
-	return null;
-}
+add_action('plugins_loaded', array('Flizpay_Sentry', 'init'), 1);
 
 function flizpay_check_dependencies()
 {

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -187,14 +187,16 @@ function flizpay_init_gateway_class()
                             $this->update_option('flizpay_api_key', '');
                         }
                     } catch (\Exception $e) {
-                        \Sentry\withScope(static function (\Sentry\State\Scope $scope) use ($e): void {
-                            $scope->setExtras([
-                                'function_name' => 'test_gateway_connection',
-                                'message' => 'Exception occurred while establishing connection to FLIZpay',
-                                'plugin_version' => self::$VERSION,
-                            ]);
+                        flizpay_sentry_with_scope(static function ($scope) use ($e): void {
+                            if ($scope && method_exists($scope, 'setExtras')) {
+                                $scope->setExtras([
+                                    'function_name' => 'test_gateway_connection',
+                                    'message' => 'Exception occurred while establishing connection to FLIZpay',
+                                    'plugin_version' => self::$VERSION,
+                                ]);
+                            }
 
-                            \Sentry\captureException($e);
+                            flizpay_sentry_capture_exception($e);
                         });
                         $this->update_option('flizpay_api_key', '');
                     }
@@ -419,16 +421,18 @@ function flizpay_init_gateway_class()
                     );
                 }
             } catch (\Exception $e) {
-                \Sentry\withScope(static function (\Sentry\State\Scope $scope) use ($e, $order, $order_id): void {
-                    $scope->setExtras([
-                        'function_name' => 'process_payment',
-                        'message' => 'Exception during payment processing',
-                        'order_id' => $order_id ?? null,
-                        'shop_url' => home_url() ?? null,
-                        'plugin_version' => self::$VERSION,
-                    ]);
+                flizpay_sentry_with_scope(static function ($scope) use ($e, $order, $order_id): void {
+                    if ($scope && method_exists($scope, 'setExtras')) {
+                        $scope->setExtras([
+                            'function_name' => 'process_payment',
+                            'message' => 'Exception during payment processing',
+                            'order_id' => $order_id ?? null,
+                            'shop_url' => home_url() ?? null,
+                            'plugin_version' => self::$VERSION,
+                        ]);
+                    }
 
-                    \Sentry\captureException($e);
+                    flizpay_sentry_capture_exception($e);
                 });
                 wc_add_notice('Error creating FLIZpay transaction. Please try again later.');
                 return array(
@@ -526,15 +530,17 @@ function flizpay_init_gateway_class()
                 ));
                 die();
             } catch (\Exception $e) {
-                \Sentry\withScope(static function (\Sentry\State\Scope $scope) use ($e): void {
-                    $scope->setExtras([
-                        'function_name' => 'flizpay_express_checkout',
-                        'message' => 'Exception occurred while processing express checkout',
-                        'shop_url' => home_url() ?? null,
-                        'plugin_version' => self::$VERSION,
-                    ]);
+                flizpay_sentry_with_scope(static function ($scope) use ($e): void {
+                    if ($scope && method_exists($scope, 'setExtras')) {
+                        $scope->setExtras([
+                            'function_name' => 'flizpay_express_checkout',
+                            'message' => 'Exception occurred while processing express checkout',
+                            'shop_url' => home_url() ?? null,
+                            'plugin_version' => self::$VERSION,
+                        ]);
+                    }
 
-                    \Sentry\captureException($e);
+                    flizpay_sentry_capture_exception($e);
                 });
                 wp_send_json_error(['message' => 'Express checkout failed. Please try again.']);
                 die();

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -187,7 +187,7 @@ function flizpay_init_gateway_class()
                             $this->update_option('flizpay_api_key', '');
                         }
                     } catch (\Exception $e) {
-                        flizpay_sentry_with_scope(static function ($scope) use ($e): void {
+                        Flizpay_Sentry::with_scope(static function ($scope) use ($e): void {
                             if ($scope && method_exists($scope, 'setExtras')) {
                                 $scope->setExtras([
                                     'function_name' => 'test_gateway_connection',
@@ -196,7 +196,7 @@ function flizpay_init_gateway_class()
                                 ]);
                             }
 
-                            flizpay_sentry_capture_exception($e);
+                            Flizpay_Sentry::capture_exception($e);
                         });
                         $this->update_option('flizpay_api_key', '');
                     }
@@ -421,7 +421,7 @@ function flizpay_init_gateway_class()
                     );
                 }
             } catch (\Exception $e) {
-                flizpay_sentry_with_scope(static function ($scope) use ($e, $order, $order_id): void {
+                Flizpay_Sentry::with_scope(static function ($scope) use ($e, $order, $order_id): void {
                     if ($scope && method_exists($scope, 'setExtras')) {
                         $scope->setExtras([
                             'function_name' => 'process_payment',
@@ -432,7 +432,7 @@ function flizpay_init_gateway_class()
                         ]);
                     }
 
-                    flizpay_sentry_capture_exception($e);
+                    Flizpay_Sentry::capture_exception($e);
                 });
                 wc_add_notice('Error creating FLIZpay transaction. Please try again later.');
                 return array(
@@ -530,7 +530,7 @@ function flizpay_init_gateway_class()
                 ));
                 die();
             } catch (\Exception $e) {
-                flizpay_sentry_with_scope(static function ($scope) use ($e): void {
+                Flizpay_Sentry::with_scope(static function ($scope) use ($e): void {
                     if ($scope && method_exists($scope, 'setExtras')) {
                         $scope->setExtras([
                             'function_name' => 'flizpay_express_checkout',
@@ -540,7 +540,7 @@ function flizpay_init_gateway_class()
                         ]);
                     }
 
-                    flizpay_sentry_capture_exception($e);
+                    Flizpay_Sentry::capture_exception($e);
                 });
                 wp_send_json_error(['message' => 'Express checkout failed. Please try again.']);
                 die();

--- a/includes/class-flizpay-sentry.php
+++ b/includes/class-flizpay-sentry.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * FLIZpay Sentry Helper Class
+ *
+ * Handles all Sentry error tracking functionality with proper checks
+ * for PHP version and Sentry availability.
+ *
+ * @package Flizpay
+ * @since 2.4.11
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Flizpay_Sentry {
+    
+    /**
+     * Minimum PHP version required for Sentry
+     */
+    const MIN_PHP_VERSION = '8.2.0';
+    
+    /**
+     * Check if Sentry can be initialized
+     *
+     * @return bool
+     */
+    public static function can_initialize() {
+        return version_compare(PHP_VERSION, self::MIN_PHP_VERSION, '>=');
+    }
+    
+    /**
+     * Initialize Sentry if requirements are met
+     */
+    public static function init() {
+        // Skip if PHP version is too low
+        if (!self::can_initialize()) {
+            return;
+        }
+        
+        // Skip if autoloader wasn't loaded
+        if (!function_exists('\Sentry\init')) {
+            return;
+        }
+        
+        // Check for user consent
+        $flizpay_settings = get_option('woocommerce_flizpay_settings', []);
+        
+        if (!isset($flizpay_settings['flizpay_sentry_enabled'])) {
+            $flizpay_settings['flizpay_sentry_enabled'] = 'yes';
+            update_option('woocommerce_flizpay_settings', $flizpay_settings);
+        }
+        
+        // Initialize Sentry
+        \Sentry\init([
+            'dsn' => 'https://d2941234a076cdd12190f707115ca5c9@o4507078336053248.ingest.de.sentry.io/4509638952419408',
+            'traces_sample_rate' => 1,
+            'before_send' => [__CLASS__, 'before_send_callback']
+        ]);
+    }
+    
+    /**
+     * Sentry before_send callback
+     *
+     * @param \Sentry\Event $event
+     * @return \Sentry\Event|null
+     */
+    public static function before_send_callback(\Sentry\Event $event) {
+        // Check if error reporting is enabled
+        $flizpay_settings = get_option('woocommerce_flizpay_settings', []);
+        $disabled = ($flizpay_settings['flizpay_sentry_enabled'] ?? '') !== 'yes';
+        if ($disabled) {
+            return null;
+        }
+        
+        // Check per-event ignore flag
+        $should_ignore_event = ($event->getExtra()['ignore_for_sentry'] ?? 'false') === 'true';
+        if ($should_ignore_event) {
+            return null;
+        }
+        
+        // Only send errors from FLIZpay plugin
+        $pluginPath = plugin_dir_path(dirname(__FILE__));
+        
+        // Check exceptions
+        foreach ($event->getExceptions() ?? [] as $exc) {
+            if (!$stack = $exc->getStacktrace()) {
+                continue;
+            }
+            foreach ($stack->getFrames() as $frame) {
+                if (($file = $frame->getFile()) && strpos($file, $pluginPath) === 0) {
+                    return $event;
+                }
+            }
+        }
+        
+        // Check message events
+        if ($stack = $event->getStacktrace()) {
+            foreach ($stack->getFrames() as $frame) {
+                if (($file = $frame->getFile()) && strpos($file, $pluginPath) === 0) {
+                    return $event;
+                }
+            }
+        }
+        
+        // No frames under our plugin dir
+        return null;
+    }
+    
+    /**
+     * Safe wrapper for Sentry\withScope
+     *
+     * @param callable $callback
+     * @return mixed|null
+     */
+    public static function with_scope($callback) {
+        if (function_exists('\Sentry\withScope')) {
+            return \Sentry\withScope($callback);
+        }
+        return null;
+    }
+    
+    /**
+     * Safe wrapper for Sentry\captureException
+     *
+     * @param \Throwable $exception
+     * @return \Sentry\EventId|null
+     */
+    public static function capture_exception($exception) {
+        if (function_exists('\Sentry\captureException')) {
+            return \Sentry\captureException($exception);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Description

- Sentry did not load correctly sometimes if the PHP version was below 8.2 and also a race condition where it tried to initialize before being available

---


## Tests

- [x] Uploaded folder to flizpay.store and made a payment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility by ensuring error tracking only initializes after WordPress is fully loaded.
  * Sentry error tracking will now only activate on PHP 8.2 or higher, preventing issues on unsupported PHP versions.
  * Dependencies for error tracking are loaded conditionally based on PHP version and file availability.
  * Enhanced error event filtering to reduce unnecessary reports based on user consent and plugin-specific criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->