### PR TITLE
feat: add product name to express checkout order

### DIFF
--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -501,18 +501,20 @@ function flizpay_init_gateway_class()
 
                 foreach (WC()->cart->get_cart() as $cart_item_key => $cart_item) {
                     $item = new WC_Order_Item_Product();
+                    $product = wc_get_product($cart_item['product_id']);
 
                     $item->set_props(array(
-                        'product_id' => $cart_item['product_id'],
+                        'name'         => $product ? $product->get_name() : '',
+                        'product_id'   => $cart_item['product_id'],
                         'variation_id' => $cart_item['variation_id'],
-                        'quantity' => $cart_item['quantity'],
+                        'quantity'     => $cart_item['quantity'],
 
                         // Use the cart's exact line subtotals/line totals (reflects discounts & sale prices)
-                        'subtotal' => $cart_item['line_subtotal'],
-                        'total' => $cart_item['line_total'],
+                        'subtotal'     => $cart_item['line_subtotal'],
+                        'total'        => $cart_item['line_total'],
                         'subtotal_tax' => $cart_item['line_subtotal_tax'],
-                        'total_tax' => $cart_item['line_tax'],
-                        'taxes' => $cart_item['line_tax_data'],
+                        'total_tax'    => $cart_item['line_tax'],
+                        'taxes'        => $cart_item['line_tax_data'],
                     ));
 
                     $order->add_item($item);


### PR DESCRIPTION
## Description

Add product name to express checkout order

Some Woocommerce plugins (such as Faktur Pro for Woocommerce) rely on cart item name and therefore mark this field as required. Current implementation of FLIZpay express checkout handler is not sending this field and when shop owner tries to generate invoice report some items might slip away from this report or report generation might be refused at all.

---


## Tests

- [x] Payed express checkout with Revolut

---

## Screenshots / Videos
If there are any UI changes please add screenshots or videos:

Before:
<img width="1082" height="1124" alt="Screenshot 2025-07-22 at 10 48 23" src="https://github.com/user-attachments/assets/4d2fd7a2-a30d-4f12-b0db-8667bb7aa1e8" />

After:
<img width="1095" height="1131" alt="Screenshot 2025-07-22 at 10 48 36" src="https://github.com/user-attachments/assets/b8432d1a-c767-4635-81e8-b8a5790785d6" />


## Notion Ticket
[NOTION TICKET](https://www.notion.so/33-2370aa2641a780069198cde69aa32567?source=copy_link)
---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Order details now include product names for each cart item during express checkout, improving order clarity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->