### PR TITLE
release: v2.4.12

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,9 @@
 == FLIZpay for WooCommerce Changelog ==
 
+2025-25-07 - version 2.4.12
+* Added - Product name to express checkout order
+* Fixed – Shipping options not shown for addresses with house number/sub-unit format.
+
 2025-18-07 - version 2.4.11
 * Fixed - Sentry Integration: Fixed sentry loading error
 

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: Flizpay
 Tags: kostenlos, payments, Zahlung, cashback, no-fee
 Requires at least: 4.4
 Tested up to: 6.7
-Stable tag: 2.4.11
+Stable tag: 2.4.12
 Requires PHP: 7.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.txt
@@ -210,7 +210,15 @@ Der erste Schritt, um FLIZpay in deinem Checkout zu installieren, ist die Erstel
 - v2.4.11
   - Fixed - Sentry Integration: Fixed sentry loading error.
 
+- v2.4.12
+  - Added - Product name to express checkout order
+  - Fixed – Shipping options not shown for addresses with house number/sub-unit format.
+
 == Upgrade Notice ==
+
+= 2.4.12 =
+* Added - Product name to express checkout order
+* Fixed – Shipping options not shown for addresses with house number/sub-unit format.
 
 = 2.4.11 =
 * Fixed - Sentry Integration: Fixed sentry loading error.

--- a/flizpay.php
+++ b/flizpay.php
@@ -16,7 +16,7 @@
  * Plugin Name:       FLIZpay Gateway für WooCommerce
  * Plugin URI:        https://www.flizpay.de/companies
  * Description:       FLIZpay: 100% free!
- * Version:           2.4.11
+ * Version:           2.4.12
  * Author:            FLIZpay
  * Author URI:        https://www.flizpay.de/companies
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if (!defined('WPINC')) {
  * Currently plugin version.
  * Start at version 1.0.0 and use SemVer - https://semver.org
  */
-define('FLIZPAY_VERSION', '2.4.11');
+define('FLIZPAY_VERSION', '2.4.12');
 
 /**
  * Load Composer autoloader only if PHP version meets requirements

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -1,6 +1,6 @@
 <?php
 if (!defined('FLIZPAY_VERSION')) {
-    define('FLIZPAY_VERSION', '2.4.11');
+    define('FLIZPAY_VERSION', '2.4.12');
 }
 
 /**

--- a/languages/flizpay-for-woocommerce-de_DE.po
+++ b/languages/flizpay-for-woocommerce-de_DE.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: FlizPay 2.4.11\n"
+"Project-Id-Version: FlizPay 2.4.12\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-07-30 10:00+0000\n"
 "PO-Revision-Date: 2024-07-30 10:00+0000\n"

--- a/languages/flizpay-for-woocommerce-en_GB.po
+++ b/languages/flizpay-for-woocommerce-en_GB.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: FlizPay 2.4.11\n"
+"Project-Id-Version: FlizPay 2.4.12\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-07-30 10:00+0000\n"
 "PO-Revision-Date: 2024-07-30 10:00+0000\n"

--- a/languages/flizpay-for-woocommerce-en_US.po
+++ b/languages/flizpay-for-woocommerce-en_US.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: FlizPay 2.4.11\n"
+"Project-Id-Version: FlizPay 2.4.12\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-07-30 10:00+0000\n"
 "PO-Revision-Date: 2024-07-30 10:00+0000\n"


### PR DESCRIPTION
## Description

Release v2.4.12

- Added - Product name to express checkout order
- Fixed – Shipping options not shown for addresses with house number/sub-unit format.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product name is now included in express checkout orders.

* **Bug Fixes**
  * Resolved an issue where shipping options were not displayed for addresses with house number or sub-unit formats.

* **Chores**
  * Updated version to 2.4.12 and refreshed related documentation and translation metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->