### PR TITLE
feat: bump tested WP version

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@
 Contributors: Flizpay
 Tags: kostenlos, payments, Zahlung, cashback, no-fee
 Requires at least: 4.4
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag: 2.4.12
 Requires PHP: 7.0
 License: GPLv2 or later


### PR DESCRIPTION
## Description

Bump tested WP version up to 6.8 (latest)

Inspected PHP and WP syntax for deprecated methods usage.

This will fix warning message in WP plugins catalogue:

<img width="1326" height="941" alt="Screenshot 2025-09-16 at 09 52 02" src="https://github.com/user-attachments/assets/9049bbce-494e-477d-9d1c-f00a286d3179" />


---


## Tests

- [x] Woocommerce checkout payment (payer-app)
- [x] Woocommerce checkout payment (payer-web)
- [x] Express checkout payment (payer-app)

---

## Notion Ticket
[NOTION TICKET](https://www.notion.so/chore-Test-with-most-recent-wordpress-so-flizpay-appears-on-searches-2350aa2641a780dfbdcfd894245c7b74?v=1064dfb8616e471a856eb063ccf8fec1&source=copy_link)

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated compatibility metadata, increasing the “Tested up to” version from 6.7 to 6.8 to reflect current platform support.
  * Clarifies supported versions for users and maintainers.
  * No functional changes, configuration updates, or behavioral impacts included in this release.
  * No action required for existing installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->