### PR TITLE
feat: hide express checkout under feature flag

### DIFF
--- a/admin/class-flizpay-admin.php
+++ b/admin/class-flizpay-admin.php
@@ -126,7 +126,7 @@ class Flizpay_Admin
 	 */
 	public function load_form_fields()
 	{
-		return array(
+		$fields = array(
 			'description_banner' => array(
 				'title' => '', // Empty title, used for HTML output
 				'type' => 'title', // Using 'title' as a workaround to insert HTML
@@ -214,15 +214,20 @@ class Flizpay_Admin
 				'default' => 'yes',
 				'desc_tip' => true,
 			),
-			'flizpay_enable_express_checkout' => array(
+		);
+
+		// Add express checkout feature fields if FLIZPAY_EXPRESS_CHECKOUT_ENABLED feature flag is enabled.
+		if (!defined('FLIZPAY_EXPRESS_CHECKOUT_ENABLED') || FLIZPAY_EXPRESS_CHECKOUT_ENABLED === true) {
+			$fields['flizpay_enable_express_checkout'] = array(
 				'title' => $this->is_english() ? 'Express checkout enabled' : 'Express-Checkout Aktiviert',
 				'type' => 'checkbox',
 				'default' => 'yes',
 				'description' => $this->is_english()
 					? 'When dealing with flat and non-taxable shipping fees, make sure the taxable option is set to “none” in the WooCommerce Shipping Zone Settings (WooCommerce > Settings > Shipping). Otherwise, the total cost calculation during express checkout may incur in taxes being applied to shipping fees.'
 					: 'Stelle für pauschale und nicht steuerpflichtige Versandkosten sicher, dass der Steuerstatus in den Einstellungen der Versandzonen (WooCommerce > Einstellungen > Versand) auf „Keine“ gesetzt ist. Andernfalls kann es bei der Berechnung der Gesamtkosten während des Express-Checkouts zu einer fehlerhaften Berechnung von Steuern auf die Versandkosten kommen.'
-			),
-			'flizpay_express_checkout_pages' => array(
+			);
+
+			$fields['flizpay_express_checkout_pages'] = array(
 				'title' => $this->is_english() ? 'Pages where the express checkout is shown' : 'Seiten, auf denen der Express-Checkout angezeigt wird',
 				'type' => 'multiselect', // Change to 'multiselect' to allow multiple selections
 				'default' => array('product', 'cart'),
@@ -232,8 +237,9 @@ class Flizpay_Admin
 				),
 				'desc_tip' => true,
 				'description' => $this->is_english() ? 'Select the pages where the express checkout button will appear.' : 'Wähle die Seiten aus, auf denen die Schaltfläche für den Express-Checkout angezeigt werden soll.'
-			),
-			'flizpay_express_checkout_theme' => array(
+			);
+
+			$fields['flizpay_express_checkout_theme'] = array(
 				'title' => $this->is_english() ? 'Express checkout button theme' : 'Design der Schaltfläche „Express-Checkout“',
 				'type' => 'select',
 				'default' => 'light',
@@ -241,8 +247,10 @@ class Flizpay_Admin
 					'light' => $this->is_english() ? 'Light' : 'Hell',
 					'dark' => $this->is_english() ? 'Dark' : 'Dunkel',
 				)
-			),
-		);
+			);
+		}
+
+		return $fields;
 	}
 
 	/**

--- a/admin/js/flizpay-admin.js
+++ b/admin/js/flizpay-admin.js
@@ -68,6 +68,7 @@ Stellen Sie dann sicher, dass Sie die Versandkostenberechnung auf dem Paket und 
     const expressCheckoutButtonTheme = document.querySelector(
       "#woocommerce_flizpay_flizpay_express_checkout_theme"
     );
+    const isEnabledExpressCheckout = !!expressCheckoutButtonTheme;
     const divider = document.createElement("hr");
     const divider2 = document.createElement("hr");
     const divider3 = document.createElement("hr");
@@ -82,10 +83,18 @@ Stellen Sie dann sicher, dass Sie die Versandkostenberechnung auf dem Paket und 
     const expressCheckoutButtonDark = document.createElement("img");
     const buttonExampleLabel = document.createElement("p");
 
-    // Remove the express checkout theme selection from the settings page
-    document.querySelector(
+    const expressCheckoutThemeRow = document.querySelector(
       "#woocommerce_flizpay_flizpay_express_checkout_theme"
-    ).parentNode.parentElement.parentElement.style.display = "none";
+    );
+    if (
+      expressCheckoutThemeRow &&
+      expressCheckoutThemeRow.parentNode &&
+      expressCheckoutThemeRow.parentNode.parentElement &&
+      expressCheckoutThemeRow.parentElement.parentElement
+    ) {
+      expressCheckoutThemeRow.parentNode.parentElement.parentElement.style.display =
+        "none";
+    }
 
     initCustomAttributesAndStyles();
 
@@ -172,10 +181,15 @@ Stellen Sie dann sicher, dass Sie die Versandkostenberechnung auf dem Paket und 
         )
       ) {
         flexibleShippingParagraph.innerHTML = flexibleShippingDisclaimer;
-        expressCheckoutButtonTheme.setAttribute("disabled", true);
-        document
-          .querySelector("#woocommerce_flizpay_flizpay_express_checkout_pages")
-          .setAttribute("disabled", true);
+        if (expressCheckoutButtonTheme) {
+          expressCheckoutButtonTheme.setAttribute("disabled", true);
+        }
+        const expressCheckoutPages = document.querySelector(
+          "#woocommerce_flizpay_flizpay_express_checkout_pages"
+        );
+        if (expressCheckoutPages) {
+          expressCheckoutPages.setAttribute("disabled", true);
+        }
       }
       jQuery("#woocommerce_flizpay_flizpay_express_checkout_pages").select2({
         placeholder: flizpayParams.wp_locale.includes("en")
@@ -194,24 +208,28 @@ Stellen Sie dann sicher, dass Sie die Versandkostenberechnung auf dem Paket und 
             .setAttribute("style", "display: none;");
       exampleImage.setAttribute("src", flizpayParams.example_image);
       exampleImage.setAttribute("width", "40%");
-      expressCheckoutButtonDark.setAttribute(
-        "src",
-        flizpayParams.express_checkout_button_dark
-      );
-      expressCheckoutButtonDark.setAttribute(
-        "width",
-        expressCheckoutButtonTheme.offsetWidth
-      );
-      expressCheckoutButtonDark.setAttribute("style", "margin-top: 10px;");
-      expressCheckoutButtonLight.setAttribute(
-        "src",
-        flizpayParams.express_checkout_button_light
-      );
-      expressCheckoutButtonLight.setAttribute(
-        "width",
-        expressCheckoutButtonTheme.offsetWidth
-      );
-      expressCheckoutButtonLight.setAttribute("style", "margin-top: 10px;");
+
+      if (isEnabledExpressCheckout) {
+        expressCheckoutButtonDark.setAttribute(
+          "src",
+          flizpayParams.express_checkout_button_dark
+        );
+        expressCheckoutButtonDark.setAttribute(
+          "width",
+          expressCheckoutButtonTheme.offsetWidth
+        );
+        expressCheckoutButtonDark.setAttribute("style", "margin-top: 10px;");
+        expressCheckoutButtonLight.setAttribute(
+          "src",
+          flizpayParams.express_checkout_button_light
+        );
+        expressCheckoutButtonLight.setAttribute(
+          "width",
+          expressCheckoutButtonTheme.offsetWidth
+        );
+        expressCheckoutButtonLight.setAttribute("style", "margin-top: 10px;");
+      }
+
       testButton.setAttribute("id", "woocommerce_flizpay_test_connection");
       resultField.setAttribute("id", "woocommerce_flizpay_connection_result");
       // Only append if apiKeyInput exists
@@ -231,23 +249,34 @@ Stellen Sie dann sicher, dass Sie die Versandkostenberechnung auf dem Paket und 
         webhookAlive.setAttribute("disabled", true);
       }
 
+      // Add unique classes to our divider rows to make them easier to find/remove
+      dividerRow.classList.add("flizpay-divider", "checkout-section");
+      dividerRow2.classList.add("flizpay-divider", "express-checkout-section");
+      dividerRow3.classList.add("flizpay-divider", "admin-options-section");
+
+      // Remove any existing dividers first to avoid duplicates
+      const existingDividers = document.querySelectorAll(".flizpay-divider");
+      existingDividers.forEach((div) => {
+        if (div.parentNode) {
+          div.parentNode.removeChild(div);
+        }
+      });
+
+      // Set styles for dividers and titles
       divider.setAttribute("style", "width: 100%");
       divider2.setAttribute("style", "width: 100%");
       divider3.setAttribute("style", "width: 100%");
-      dividerRow.setAttribute(
-        "style",
-        "width: 80vw; display: flex; flex-wrap: wrap; justify-content: center; align-items: center; padding: 10px; text-align: center;"
-      );
-      dividerRow2.setAttribute(
-        "style",
-        "width: 80vw; display: flex; flex-wrap: wrap; justify-content: center; align-items: center; padding: 10px; text-align: center; gap: 20px;"
-      );
-      dividerRow3.setAttribute(
-        "style",
-        "width: 80vw; display: flex; flex-wrap: wrap; justify-content: center; align-items: center; padding: 10px; text-align: center; gap: 20px;"
-      );
+
+      const dividerStyle =
+        "width: 80vw; display: flex; flex-wrap: wrap; justify-content: center; align-items: center; padding: 10px; text-align: center;";
+      dividerRow.setAttribute("style", dividerStyle);
+      dividerRow2.setAttribute("style", dividerStyle + " gap: 20px;");
+      dividerRow3.setAttribute("style", dividerStyle + " gap: 20px;");
+
       checkoutSectionTitle.setAttribute("style", "width: 100%;");
       expressCheckoutSectionTitle.setAttribute("style", "width: 100%;");
+
+      // Set section titles
       checkoutSectionTitle.innerHTML = flizpayParams.wp_locale.includes("en")
         ? "Checkout Settings"
         : "Kasse Einstellung";
@@ -256,12 +285,23 @@ Stellen Sie dann sicher, dass Sie die Versandkostenberechnung auf dem Paket und 
       )
         ? "Express Checkout Settings"
         : "Express-Checkout Einstellung";
+      orderStatusLabel.innerHTML = adminOptionTitle;
+
+      // Build checkout section divider
       dividerRow.append(divider);
       dividerRow.appendChild(checkoutSectionTitle);
       dividerRow.append(exampleImage);
+
+      // Build express checkout section divider
       dividerRow2.append(divider2);
       dividerRow2.appendChild(expressCheckoutSectionTitle);
       dividerRow2.append(flexibleShippingParagraph);
+
+      // Build admin options section divider
+      dividerRow3.append(divider3);
+      dividerRow3.append(orderStatusLabel);
+
+      // Set button example label
       buttonExampleLabel.innerHTML = flizpayParams.wp_locale.includes("en")
         ? "Example:"
         : "Beispiel:";
@@ -275,23 +315,63 @@ Stellen Sie dann sicher, dass Sie die Versandkostenberechnung auf dem Paket und 
         );
       }
 
-      orderStatusLabel.innerHTML = adminOptionTitle;
-      dividerRow3.append(divider3);
-      dividerRow3.append(orderStatusLabel);
+      // Find the main settings table
+      const table = document.querySelector("table.form-table > tbody");
+      if (!table) return;
 
-      if (orderStatus) {
-        orderStatus.append(dividerRow2);
+      // Add checkout section after Connection Established section
+      const connectionEstablishedRow = table.querySelector(
+        "tr:has(#woocommerce_flizpay_flizpay_webhook_alive)"
+      );
+
+      // Try finding the row with the connection description
+      const connectionDescriptionRow =
+        connectionEstablishedRow ||
+        (description ? description.closest("tr") : null);
+
+      if (connectionDescriptionRow) {
+        connectionDescriptionRow.insertAdjacentElement("afterend", dividerRow);
+      } else {
+        // Fallback: use the original approach if connection row not found
+        const apiKeyRow =
+          table.querySelector("tr:has(#woocommerce_flizpay_flizpay_api_key)") ||
+          table.querySelector("tr:nth-child(3)");
+        if (apiKeyRow) {
+          apiKeyRow.insertAdjacentElement("afterend", dividerRow);
+        }
       }
 
-      const table = document.querySelector("table > tbody");
-      if (table) {
-        const tr3 = table.querySelector("tr:nth-child(3)");
-        const tr9 = table.querySelector("tr:nth-child(9)");
-        const tr7 = table.querySelector("tr:nth-child(7)");
+      // Add admin options section before order status
+      const orderStatusRow = table.querySelector(
+        "tr:has(#woocommerce_flizpay_flizpay_order_status)"
+      );
+      if (orderStatusRow) {
+        orderStatusRow.insertAdjacentElement("beforebegin", dividerRow3);
+      }
 
-        if (tr3) tr3.insertAdjacentElement("afterend", dividerRow);
-        if (tr9) tr9.insertAdjacentElement("afterend", dividerRow2);
-        if (tr7) tr7.insertAdjacentElement("afterend", dividerRow3);
+      // Check if express checkout settings are visible
+      const expressCheckoutRow = document.querySelector(
+        "#woocommerce_flizpay_flizpay_enable_express_checkout"
+      );
+
+      if (expressCheckoutRow && expressCheckoutRow.closest("tr")) {
+        const expressRow = expressCheckoutRow.closest("tr");
+        const isVisible =
+          window.getComputedStyle(expressRow).display !== "none";
+
+        // Only add express checkout section if it's visible
+        if (isVisible) {
+          // Find sentry row to insert before it
+          const sentryRow = table.querySelector(
+            "tr:has(#woocommerce_flizpay_flizpay_sentry_enabled)"
+          );
+          if (sentryRow) {
+            sentryRow.insertAdjacentElement("beforebegin", dividerRow2);
+          } else {
+            // Fallback: append to end of table
+            table.appendChild(dividerRow2);
+          }
+        }
       }
 
       if (webhookAlive && webhookAlive.checked && description) {

--- a/flizpay.php
+++ b/flizpay.php
@@ -38,6 +38,14 @@ if (!defined('WPINC')) {
 define('FLIZPAY_VERSION', '2.4.13');
 
 /**
+ * Developer feature flag to control express checkout functionality.
+ * Set to false to disable express checkout entirely, regardless of admin settings.
+ */
+if (!defined('FLIZPAY_EXPRESS_CHECKOUT_ENABLED')) {
+	define('FLIZPAY_EXPRESS_CHECKOUT_ENABLED', false);
+}
+
+/**
  * Load Composer autoloader only if PHP version meets requirements
  */
 if (file_exists(__DIR__ . '/vendor/autoload.php') && version_compare(PHP_VERSION, '8.2.0', '>=')) {

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -103,9 +103,11 @@ function flizpay_init_gateway_class()
             // Order placed e-mail handler
             add_filter('woocommerce_email_enabled_new_order', array($this, 'disable_new_order_email_for_flizpay'), 10, 2);
 
-            // Express checkout handler
-            add_action("wp_ajax_flizpay_express_checkout", array($this, "flizpay_express_checkout"));
-            add_action("wp_ajax_nopriv_flizpay_express_checkout", array($this, "flizpay_express_checkout"));
+            // Express checkout handler - only register if feature is available
+            if ($this->is_express_checkout_available()) {
+                add_action("wp_ajax_flizpay_express_checkout", array($this, "flizpay_express_checkout"));
+                add_action("wp_ajax_nopriv_flizpay_express_checkout", array($this, "flizpay_express_checkout"));
+            }
         }
 
         /**
@@ -267,6 +269,28 @@ function flizpay_init_gateway_class()
          * 
          * @return array | null
          * 
+         * @since 1.0.0
+         */
+        /**
+         * Checks if express checkout should be available based on settings and developer flag
+         *
+         * @return boolean
+         */
+        private function is_express_checkout_available()
+        {
+            // First check the developer flag
+            if (defined('FLIZPAY_EXPRESS_CHECKOUT_ENABLED') && FLIZPAY_EXPRESS_CHECKOUT_ENABLED === false) {
+                return false;
+            }
+
+            return $this->flizpay_enable_express_checkout === 'yes';
+        }
+
+        /**
+         * Obtain the current cashback value of the merchant from the transient
+         *
+         * @return array | null
+         *
          * @since 1.0.0
          */
         public function get_cashback_data()

--- a/public/class-flizpay-public.php
+++ b/public/class-flizpay-public.php
@@ -90,8 +90,20 @@ class Flizpay_Public
         );
     }
 
+    /**
+     * Check if express checkout should be enabled
+     * Respects both the developer flag and admin settings
+     *
+     * @return bool
+     */
     public function is_express_checkout_enabled()
     {
+        // First check the developer flag - if it's false, always disable express checkout
+        if (defined('FLIZPAY_EXPRESS_CHECKOUT_ENABLED') && FLIZPAY_EXPRESS_CHECKOUT_ENABLED === false) {
+            return false;
+        }
+
+        // Otherwise, use the admin setting
         return $this->settings['flizpay_enable_express_checkout'] === "yes" &&
             $this->settings['flizpay_webhook_alive'] === 'yes';
     }
@@ -106,7 +118,6 @@ class Flizpay_Public
     {
 
         $this->enqueue_checkout_scripts();
-
     }
 
     // Enqueues the public script for the checkout page
@@ -213,5 +224,4 @@ class Flizpay_Public
             $payment_method_registry->register(new Flizpay_Gateway_Blocks);
         });
     }
-
 }


### PR DESCRIPTION
## Description

Hide express checkout under feature flag

Introduced `FLIZPAY_EXPRESS_CHECKOUT_ENABLED` global variable that controls express checkout functionality. Currently we want to remove this feature, but keep infrastructure in place.

---


## Tests

- [x] Payed express-checkout with feature enabled (Revolut)
- [x] Payed normal checkout with feature enabled (Revolut)
- [x] Payed normal checkout with feature disabled (Revolut)
- [x] Ensured that express checkout button is not visible on a product page

---

## Screenshots / Videos
If there are any UI changes please add screenshots or videos:

Express checkout enabled flag:
<img width="1468" height="845" alt="Screenshot 2025-09-19 at 10 47 34" src="https://github.com/user-attachments/assets/e2fe2fd9-6fcf-4e99-9f3a-817960719d2e" />

Express checkout disabled flag:
<img width="1471" height="842" alt="Screenshot 2025-09-19 at 10 47 10" src="https://github.com/user-attachments/assets/20bc5d00-bf88-4f48-a3d7-305358f5db76" />

## Notion Ticket
[NOTION TICKET](https://www.notion.so/feat-Remove-express-checkout-from-plugin-26c0aa2641a7807d8f40dd7ccf2c88de?v=1064dfb8616e471a856eb063ccf8fec1&source=copy_link)

---