### PR TITLE
feat: restrict non german customers to proceed with fliz payment

### DIFF
--- a/includes/class-flizpay-api-service.php
+++ b/includes/class-flizpay-api-service.php
@@ -71,7 +71,7 @@ class Flizpay_API_Service
     $body = [
       'amount' => $order->get_total(),
       'currency' => $order->get_currency(),
-      'externalId' => $order->get_id(),
+      'externalId' => (string) $order->get_id(),
       'successUrl' => $order->get_checkout_order_received_url(),
       'failureUrl' => 'https://checkout.flizpay.de/failed',
       'customer' => $customer,

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -297,12 +297,49 @@ function flizpay_init_gateway_class()
         }
 
         /**
+         * Check whether the current customer's billing country is Germany.
+         * Returns true when the country is 'DE' or when it cannot be determined
+         * (empty/guest with no address yet), so new customers are not blocked
+         * before they have entered an address.
+         *
+         * @return bool
+         *
+         * @since 2.5.0
+         */
+        private function is_german_customer(): bool
+        {
+            // Check serialised classic-checkout AJAX payload first — it reflects what
+            // the customer just typed before WC()->customer is fully updated.
+            if (!empty($_POST['post_data'])) {
+                $post_data = array();
+                parse_str(wp_unslash($_POST['post_data']), $post_data);
+                $billing_country = sanitize_text_field($post_data['billing_country'] ?? '');
+                if (!empty($billing_country)) {
+                    return $billing_country === 'DE';
+                }
+            }
+
+            if (!function_exists('WC') || !WC()->customer instanceof \WC_Customer) {
+                return true; // Fail open in ambiguous contexts (REST, CLI, cron)
+            }
+
+            $billing_country = WC()->customer->get_billing_country();
+
+            if (empty($billing_country)) {
+                return true; // No address entered yet — don't hide FLIZpay prematurely
+            }
+
+            return $billing_country === 'DE';
+        }
+
+        /**
          * This plugin is only available outside of the admin order pay page.
          * It will also be marked as unavailable when the 2-way webhook connection was not established
          * and when the configuration haven't been completed at all.
-         * 
+         * FLIZpay is a German-market product and is only shown to customers with a German billing address.
+         *
          * @return bool
-         * 
+         *
          * @since 1.0.0
          */
         public function is_available()
@@ -314,7 +351,11 @@ function flizpay_init_gateway_class()
             $available = $this->get_option('flizpay_enabled') === 'yes' &&
                 $this->get_option('flizpay_webhook_alive') === 'yes';
 
-            return $available;
+            if (!$available) {
+                return false;
+            }
+
+            return $this->is_german_customer();
         }
 
         /**
@@ -379,6 +420,5 @@ function flizpay_init_gateway_class()
                 );
             }
         }
-
     }
 }

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -310,7 +310,7 @@ function flizpay_init_gateway_class()
         {
             // Check serialised classic-checkout AJAX payload first — it reflects what
             // the customer just typed before WC()->customer is fully updated.
-            if (!empty($_POST['post_data'])) {
+            if (!empty($_POST['post_data']) && is_string($_POST['post_data'])) {
                 $post_data = array();
                 parse_str(wp_unslash($_POST['post_data']), $post_data);
                 $billing_country = sanitize_text_field($post_data['billing_country'] ?? '');

--- a/public/js/flizpay-checkout.js
+++ b/public/js/flizpay-checkout.js
@@ -38,7 +38,10 @@ const Flizpay_Gateway = {
   label: React.createElement(LabelElement, null),
   content: Object(window.wp.element.createElement)(Content, null),
   edit: Object(window.wp.element.createElement)(Content, null),
-  canMakePayment: () => true,
+  canMakePayment: ({ billingAddress }) => {
+    const country = billingAddress && billingAddress.country;
+    return !country || country === 'DE';
+  },
   ariaLabel: label,
   supports: {
     features: ["products"], //settings.supports,


### PR DESCRIPTION
## Description

FLIZpay is a German-market-only payment product. Foreign customers (e.g. Austria, Netherlands) were seeing FLIZpay at checkout and attempting to use it, resulting in a failed payment experience since FLIZpay only supports German bank accounts. This PR introduces a Germany-only restriction so FLIZpay is silently hidden from any customer whose billing address is outside Germany.

A separate bug was also discovered and fixed during testing: externalId in the transaction creation payload was being sent as an integer, which the API rejects with a 400 validation error. This caused every checkout attempt to fail silently.


## Changes

1. Germany-only restriction — server-side (includes/class-flizpay-gateway.php)

Added a new private method `is_german_customer()` and wired it into the existing `is_available()` gate.

`is_german_customer()` logic:
- Reads `billing_country` from `$_POST['post_data']` first. This is the serialised form payload sent during the classic-checkout AJAX (update_order_review) and reflects what the customer just typed, before `WC()->customer` is fully updated in memory.
- Falls back to `WC()->customer->get_billing_country()` for all other contexts (direct page render, WooCommerce Store REST API, logged-in customers with a saved address).
- Fails open in two cases: when the country field is empty (customer hasn't typed their address yet — avoids hiding FLIZpay prematurely) and when `WC()->customer` is not initialised (REST API background calls, WP-CLI, cron).

`is_available()` now short-circuits early if the gateway is disabled/webhook is dead, then delegates the final check to `is_german_customer()`. The admin order-pay page guard is unchanged and continues to fire first.

2. Germany-only restriction — blocks checkout (public/js/flizpay-checkout.js)

The WooCommerce Blocks checkout registers payment methods once on page load and evaluates a `canMakePayment` callback to determine visibility. The previous implementation was `canMakePayment: () => true`, which meant the payment method was never re-evaluated when the customer changed their billing country in the form — FLIZpay remained visible regardless of the selected country.

Updated `canMakePayment` to receive the billingAddress context object provided by the WooCommerce Blocks payment method API and check billingAddress.country.

3. Bug fix — `externalId` type mismatch (includes/class-flizpay-api-service.php)

`WC_Order::get_id()` returns an int in PHP. When JSON-encoded, this produced a numeric value in the request body. The FLIZpay API enforces a strict string type on externalId and returns a 400 validation error when it receives a number:

`{"field": "externalId", "message": "Invalid type: Expected string but received 999"}`

Because dispatch() is called with `$api_mode = false` in `create_transaction()`, this API error was silently swallowed — dispatch() returned null, create_transaction() returned null, and process_payment() returned failure with an empty redirect URL, manifesting as a WooCommerce 400 at the Store API level with no user-visible explanation.

---


## Tests

- [x] tested checkout UX with non-German billing address
- [x] filled in German billing address and successfully completed transaction

---

## Screenshots / Videos

https://github.com/user-attachments/assets/56ad46be-4272-49c6-9d40-7418433f1b7e




## Notion Ticket
[NOTION TICKET](https://www.notion.so/bug-woocommerce-error-3420aa2641a780a18c38d619c55a7010?v=1064dfb8616e471a856eb063ccf8fec1&source=copy_link)

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Flizpay payment gateway is now restricted to customers with German billing addresses.

* **Bug Fixes**
  * Improved transaction ID data formatting in payment requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->