### PR TITLE
release: v2.4.18

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,11 @@
 == FLIZpay for WooCommerce Changelog ==
 
+2026-04-15 - version 2.4.18
+* Added   - FLIZpay is now only shown to customers with a German billing address
+* Removed - Remaining express checkout code and settings
+* Fixed   - Payment creation failing due to order ID type mismatch with the API
+* Fixed   - Added type guard before parsing classic checkout AJAX payload
+
 2026-02-19 - version 2.4.17
 * Hotfix - Restore missing WordPress.org plugin directory assets (icon, screenshots)
 

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: Flizpay
 Tags: kostenlos, payments, Zahlung, cashback, no-fee
 Requires at least: 4.4
 Tested up to: 6.8
-Stable tag: 2.4.17
+Stable tag: 2.4.18
 Requires PHP: 7.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.txt
@@ -229,7 +229,19 @@ Der erste Schritt, um FLIZpay in deinem Checkout zu installieren, ist die Erstel
 - v2.4.17
   - Hotfix - Restore missing WordPress.org plugin directory assets (icon, screenshots)
 
+- v2.4.18
+  - Added   - FLIZpay is now only shown to customers with a German billing address
+  - Removed - Remaining express checkout code and settings
+  - Fixed   - Payment creation failing due to order ID type mismatch with the API
+  - Fixed   - Added type guard before parsing classic checkout AJAX payload
+
 == Upgrade Notice ==
+
+= 2.4.18 =
+* Added   - FLIZpay is now only shown to customers with a German billing address
+* Removed - Remaining express checkout code and settings
+* Fixed   - Payment creation failing due to order ID type mismatch with the API
+* Fixed   - Added type guard before parsing classic checkout AJAX payload
 
 = 2.4.17 =
 * Hotfix - Restore missing WordPress.org plugin directory assets (icon, screenshots)

--- a/flizpay.php
+++ b/flizpay.php
@@ -16,7 +16,7 @@
  * Plugin Name:       FLIZpay Gateway für WooCommerce
  * Plugin URI:        https://www.flizpay.de/companies
  * Description:       FLIZpay: 100% free!
- * Version:           2.4.17
+ * Version:           2.4.18
  * Author:            FLIZpay
  * Author URI:        https://www.flizpay.de/companies
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ if (!defined('WPINC')) {
  * Currently plugin version.
  * Start at version 1.0.0 and use SemVer - https://semver.org
  */
-define('FLIZPAY_VERSION', '2.4.17');
+define('FLIZPAY_VERSION', '2.4.18');
 
 /**
  * Load Composer autoloader only if PHP version meets requirements

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -1,6 +1,6 @@
 <?php
 if (!defined('FLIZPAY_VERSION')) {
-    define('FLIZPAY_VERSION', '2.4.17');
+    define('FLIZPAY_VERSION', '2.4.18');
 }
 
 /**

--- a/languages/flizpay-for-woocommerce-de_DE.po
+++ b/languages/flizpay-for-woocommerce-de_DE.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: FlizPay 2.4.17\n"
+"Project-Id-Version: FlizPay 2.4.18\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-07-30 10:00+0000\n"
 "PO-Revision-Date: 2024-07-30 10:00+0000\n"

--- a/languages/flizpay-for-woocommerce-en_GB.po
+++ b/languages/flizpay-for-woocommerce-en_GB.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: FlizPay 2.4.17\n"
+"Project-Id-Version: FlizPay 2.4.18\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-07-30 10:00+0000\n"
 "PO-Revision-Date: 2024-07-30 10:00+0000\n"

--- a/languages/flizpay-for-woocommerce-en_US.po
+++ b/languages/flizpay-for-woocommerce-en_US.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: FlizPay 2.4.17\n"
+"Project-Id-Version: FlizPay 2.4.18\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-07-30 10:00+0000\n"
 "PO-Revision-Date: 2024-07-30 10:00+0000\n"


### PR DESCRIPTION
## Description

Release v2.4.18

* Added   - FLIZpay is now only shown to customers with a German billing address
* Removed - Remaining express checkout code and settings
* Fixed   - Payment creation failing due to order ID type mismatch with the API
* Fixed   - Added type guard before parsing classic checkout AJAX payload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed payment creation failures caused by order ID type mismatches
  * Added type validation for classic checkout processing

* **Chores**
  * Version 2.4.18 released
  * Restricted FLIZpay to customers with German billing address
  * Removed express checkout functionality and related settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->