### PR TITLE
fix: guard flizpay_upgrader against non-plugin upgrade hooks

### DIFF
--- a/flizpay.php
+++ b/flizpay.php
@@ -110,9 +110,13 @@ function flizpay_deactivate()
 
 function flizpay_upgrader($upgrader, $options = null)
 {
+	if (! is_array($options) || empty($options['plugins']) || ! is_array($options['plugins'])) {
+		return;
+	}
+
 	$plugin = plugin_basename(__FILE__);
 
-	if ($options['action'] == 'update' && $options['type'] == 'plugin' && $options['plugins'][0] == $plugin) {
+	if (($options['action'] ?? '') === 'update' && ($options['type'] ?? '') === 'plugin' && in_array($plugin, $options['plugins'], true)) {
 		require_once plugin_dir_path(__FILE__) . 'includes/class-flizpay-activator.php';
 		Flizpay_Activator::activate();
 	}


### PR DESCRIPTION
## Summary
- `upgrader_process_complete` fires for theme, translation, and core updates too — where `\$options['plugins']` is absent. Accessing `\$options['plugins'][0]` raised `Warning: Trying to access array offset on null` (seen in Sentry on both a WP core plugin install flow and a MalCare-triggered theme bulk upgrade).
- Early-return unless `plugins` is a non-empty array, and use `in_array` so bulk plugin updates where flizpay isn't at index 0 still trigger activation.

## Test plan
- [ ] Update the flizpay plugin via WP admin → activator still runs
- [ ] Trigger a theme/translation update → no PHP warning, activator does not run
- [ ] Bulk-update multiple plugins including flizpay → activator runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability and error handling to prevent potential crashes and ensure more reliable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->