### PR TITLE
feat: add restrict to germany settings option

### DIFF
--- a/admin/class-flizpay-admin.php
+++ b/admin/class-flizpay-admin.php
@@ -217,6 +217,18 @@ class Flizpay_Admin
 				),
 				'desc_tip' => true,
 			),
+			'flizpay_restrict_to_germany' => array(
+				'title' => $this->is_english() ? 'Restrict to Germany' : 'Auf Deutschland beschränken',
+				'label' => $this->is_english()
+					? 'Only show FLIZpay for customers with a German billing address'
+					: 'FLIZpay nur für Kunden mit deutscher Rechnungsadresse anzeigen',
+				'type' => 'checkbox',
+				'description' => $this->is_english()
+					? 'Only show FLIZpay to customers with a German billing address. Leave disabled to offer FLIZpay worldwide.'
+					: 'FLIZpay nur Kunden mit deutscher Rechnungsadresse anzeigen. Deaktiviert lassen, um FLIZpay weltweit anzubieten.',
+				'default' => 'no',
+				'desc_tip' => true,
+			),
 			'flizpay_sentry_enabled' => array(
 				'title' => $this->is_english() ? 'Error Reporting' : 'Fehlerberichte',
 				'label' => $this->is_english() ? 'Enable error reporting to improve plugin stability' : 'Fehlerberichte aktivieren, um die Plugin-Stabilität zu verbessern',

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -28,6 +28,7 @@ function flizpay_init_gateway_class()
         public $flizpay_display_headline;
         public $flizpay_order_status;
         public $flizpay_sentry_enabled;
+        public $flizpay_restrict_to_germany;
         public $cashback_helper;
         public $webhook_helper;
         public $api_service;
@@ -70,6 +71,7 @@ function flizpay_init_gateway_class()
             $this->flizpay_display_headline = $this->get_option('flizpay_display_headline');
             $this->flizpay_order_status = $this->get_option('flizpay_order_status');
             $this->flizpay_sentry_enabled = $this->get_option('flizpay_sentry_enabled');
+            $this->flizpay_restrict_to_germany = $this->get_option('flizpay_restrict_to_germany');
             // Initialize helper classes
             $this->cashback_helper = new Flizpay_Cashback_Helper($this);
             $this->webhook_helper = new Flizpay_Webhook_Helper($this);
@@ -216,6 +218,13 @@ function flizpay_init_gateway_class()
                     $this->update_option('flizpay_order_status', 'wc-pending');
                 }
 
+                if (isset($_POST['woocommerce_flizpay_flizpay_restrict_to_germany'])) {
+                    $flizpay_restrict_to_germany = sanitize_text_field(wp_unslash($_POST['woocommerce_flizpay_flizpay_restrict_to_germany']));
+                    $this->update_option('flizpay_restrict_to_germany', $flizpay_restrict_to_germany === '1' ? 'yes' : 'no');
+                } else {
+                    $this->update_option('flizpay_restrict_to_germany', 'no');
+                }
+
                 if (isset($_POST['woocommerce_flizpay_flizpay_sentry_enabled'])) {
                     $flizpay_sentry_enabled = sanitize_text_field(wp_unslash($_POST['woocommerce_flizpay_flizpay_sentry_enabled']));
                     $this->update_option('flizpay_sentry_enabled', $flizpay_sentry_enabled === '1' ? 'yes' : 'no');
@@ -336,7 +345,9 @@ function flizpay_init_gateway_class()
          * This plugin is only available outside of the admin order pay page.
          * It will also be marked as unavailable when the 2-way webhook connection was not established
          * and when the configuration haven't been completed at all.
-         * FLIZpay is a German-market product and is only shown to customers with a German billing address.
+         * When the merchant opts in via the "Restrict to Germany" setting, FLIZpay is additionally
+         * hidden for customers whose billing country is not DE. By default the restriction is off,
+         * since customers abroad may still bank with FLIZpay-supported providers (e.g. N26, Revolut).
          *
          * @return bool
          *
@@ -355,7 +366,15 @@ function flizpay_init_gateway_class()
                 return false;
             }
 
-            return $this->is_german_customer();
+            // Country restriction is opt-in. Off by default so merchants can still
+            // reach customers abroad who bank with FLIZpay-supported providers
+            // (e.g. N26, Revolut). Shop owners who only serve Germany can enable
+            // the "Restrict to Germany" setting to hide FLIZpay for non-DE addresses.
+            if ($this->get_option('flizpay_restrict_to_germany') === 'yes') {
+                return $this->is_german_customer();
+            }
+
+            return true;
         }
 
         /**

--- a/public/flizpay-gateway-blocks.php
+++ b/public/flizpay-gateway-blocks.php
@@ -69,6 +69,7 @@ final class Flizpay_Gateway_Blocks extends AbstractPaymentMethodType
             'title' => $this->gateway->title,
             'description' => $this->gateway->description,
             'icon' => $this->gateway->icon,
+            'restrictToGermany' => $this->gateway->get_option('flizpay_restrict_to_germany') === 'yes',
         ];
     }
 }

--- a/public/js/flizpay-checkout.js
+++ b/public/js/flizpay-checkout.js
@@ -29,7 +29,7 @@ function LabelElement() {
         width: "68",
         height: "36",
         src: settings.icon,
-      })
+      }),
   );
 }
 
@@ -39,8 +39,12 @@ const Flizpay_Gateway = {
   content: Object(window.wp.element.createElement)(Content, null),
   edit: Object(window.wp.element.createElement)(Content, null),
   canMakePayment: ({ billingAddress }) => {
+    if (!settings.restrictToGermany) {
+      return true;
+    }
+
     const country = billingAddress && billingAddress.country;
-    return !country || country === 'DE';
+    return !country || country === "DE";
   },
   ariaLabel: label,
   supports: {


### PR DESCRIPTION
# Make Germany Restriction Optional

## Summary

This PR replaces FLIZpay’s hardcoded Germany-only checkout behavior with an optional merchant setting. The current restriction is too strict for shops whose customers live outside Germany but still use FLIZpay-supported banks, so the new default keeps FLIZpay available unless the merchant explicitly chooses to limit it to German billing addresses.

## Key Changes

- Add a new admin checkbox setting: Restrict to Germany.
- Default the setting to off, so FLIZpay remains available outside Germany unless the merchant explicitly enables the restriction.
- Persist the new setting in the gateway’s custom admin save flow.
- Update gateway availability logic so non-DE billing addresses are blocked only when the new setting is enabled.
- Pass the setting into the blocks integration and update canMakePayment() so blocks checkout matches classic checkout behavior.


---


## Tests

- [x]  With Restrict to Germany disabled, confirm FLIZpay is shown for both German and non-German billing addresses in classic checkout.
- [x] With Restrict to Germany enabled, confirm FLIZpay is hidden for non-German billing addresses and still shown for German billing addresses.
- [x] Confirm WooCommerce Blocks checkout follows the same behavior as classic checkout for both enabled and disabled states.

---

## Screenshots / Videos
If there are any UI changes please add screenshots or videos:

<img width="1209" height="398" alt="Screenshot 2026-04-22 at 19 16 35" src="https://github.com/user-attachments/assets/5c9248f5-0403-47dc-986b-93d80508527d" />


## Notion Ticket
[NOTION TICKET](https://www.notion.so/feat-add-new-setting-to-woocommerce-plugin-to-allow-customer-country-restriction-34a0aa2641a780058ca0e045294a612b?v=1064dfb8616e471a856eb063ccf8fec1&source=copy_link)

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional admin setting to restrict payment method availability to German customers only. When enabled, the payment method is only available at checkout for customers with German billing addresses.

* **Bug Fixes**
  * Improved payment method availability logic to support conditional country restrictions based on admin configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->