### PR TITLE
fix: complete order idempotency

### DIFF
--- a/includes/class-flizpay-webhook-helper.php
+++ b/includes/class-flizpay-webhook-helper.php
@@ -175,11 +175,22 @@ class Flizpay_Webhook_Helper
 
   private function complete_order($order, $data)
   {
+    $incoming_tx = isset($data['transactionId']) ? sanitize_text_field((string) $data['transactionId']) : '';
+
+    if ($incoming_tx !== '' && $order->get_meta('_flizpay_completed_tx') === $incoming_tx) {
+      return;
+    }
+
     // Explicitly set the payment method before completing payment
     $order->set_payment_method('flizpay');
     $order->set_payment_method_title('FLIZpay');
 
-    $order->payment_complete($data['transactionId']);
+    $order->payment_complete($incoming_tx);
+
+    if ($incoming_tx !== '') {
+      $order->update_meta_data('_flizpay_completed_tx', $incoming_tx);
+    }
+
     $fliz_discount = (float) $data['originalAmount'] - (float) $data['amount'];
     $cashback_value = (float) ($fliz_discount * 100) / $data['originalAmount'];
 
@@ -187,8 +198,8 @@ class Flizpay_Webhook_Helper
       $this->apply_cashback_discount($data, $order, $cashback_value, $fliz_discount, $data['currency']);
     }
 
-    if (isset($data['transactionId'])) {
-      $order->add_order_note('FLIZ transaction ID: ' . sanitize_text_field($data['transactionId']));
+    if ($incoming_tx !== '') {
+      $order->add_order_note('FLIZ transaction ID: ' . $incoming_tx);
     }
 
     $this->send_order_emails($order->get_id());


### PR DESCRIPTION
## Summary

Adds a transaction-id-keyed idempotency guard to `complete_order` so a duplicate FLIZ webhook delivery for the same payment doesn't re-apply the cashback discount, duplicate the order note, or re-send customer emails.

## Why now

The FLIZ backend webhook delivery is moving to at-least-once semantics. On any axios timeout, lost ACK, or mid-flight claim reclaim, the backend will re-POST. Without a guard, every retry that the shop successfully processes compounds: line items get discounted twice, an extra "FLIZ transaction ID" note is added, and emails fire again.

## What changed

`includes/class-flizpay-webhook-helper.php` — `complete_order` now:

1. Reads `$data['transactionId']`.
2. Returns early when `_flizpay_completed_tx` order meta matches the incoming tx id (the duplicate-delivery case).
3. Writes `_flizpay_completed_tx` right after `payment_complete()` succeeds, before any side effect runs.

WC's `payment_complete` is already idempotent; the actual damage came from `apply_cashback_discount`, `add_order_note`, and `send_order_emails`, all of which now short-circuit on a duplicate.

## Trade-offs

- Marker is written between `payment_complete` and the side effects. A partial failure between those two points (e.g. an email error) blocks the retry from finishing the remaining work — the order is still correctly marked paid, but the email might not send. Acceptable: no double-cashback is the priority. This is how Stripe/Adyen handle webhook idempotency.
- Orders completed before this version don't have the marker. Backend marks `deliveredAt` on success and won't re-deliver those, so it's only a concern in a narrow window during the rollout.
- Uses WC's order-meta API (`get_meta`/`update_meta_data`) so it works for both legacy CPT and (future) HPOS storage.

## Test plan

- [x] Completed successfully plugin transaction (staging env)

---

## Notion Ticket
[NOTION TICKET](https://www.notion.so/feat-add-webhook-idempotency-guard-3610aa2641a7800eb17ae0d0972ff25f?source=copy_link)

---