### PR TITLE
feat: security audit hardening

### DIFF
--- a/includes/class-flizpay-api-service.php
+++ b/includes/class-flizpay-api-service.php
@@ -80,6 +80,16 @@ class Flizpay_API_Service
     $client = WC_Flizpay_API::get_instance($this->api_key);
     $response = $client->dispatch('create_transaction', $body, false);
 
-    return $response['redirectUrl'] ?? null;
+    $redirect_url = $response['redirectUrl'] ?? null;
+    $transaction_id = isset($response['transactionId']) ? (string) $response['transactionId'] : '';
+
+    if (!$redirect_url || $transaction_id === '') {
+      return null;
+    }
+
+    return [
+      'redirectUrl' => $redirect_url,
+      'transactionId' => $transaction_id,
+    ];
   }
 }

--- a/includes/class-flizpay-gateway.php
+++ b/includes/class-flizpay-gateway.php
@@ -407,10 +407,18 @@ function flizpay_init_gateway_class()
                 $order->update_status($this->flizpay_order_status, 'FLIZpay Checkout initiated. Waiting for payment - ' . $source);
                 $order->save();
 
-                $redirectUrl = $this->api_service->create_transaction($order, $source);
+                $transaction = $this->api_service->create_transaction($order, $source);
 
-                if ($redirectUrl) {
-                    return array('result' => 'success', 'redirect' => $redirectUrl, 'order_id' => $order_id);
+                if (is_array($transaction) && !empty($transaction['redirectUrl']) && !empty($transaction['transactionId'])) {
+                    $issued = $order->get_meta('_flizpay_issued_tx_ids');
+                    if (!is_array($issued)) {
+                        $issued = array();
+                    }
+                    $issued[] = $transaction['transactionId'];
+                    $order->update_meta_data('_flizpay_issued_tx_ids', $issued);
+                    $order->save();
+
+                    return array('result' => 'success', 'redirect' => $transaction['redirectUrl'], 'order_id' => $order_id);
                 } else {
                     wc_add_notice('Error creating FLIZpay transaction. Please try again later.');
                     return array(

--- a/includes/class-flizpay-webhook-helper.php
+++ b/includes/class-flizpay-webhook-helper.php
@@ -28,11 +28,6 @@ class Flizpay_Webhook_Helper
       return true;
     }
 
-    // Flush if webhook key is empty
-    if (empty($this->gateway->get_option('flizpay_webhook_key'))) {
-      return true;
-    }
-
     // Check if our rewrite rule exists in WordPress rewrite rules
     global $wp_rewrite;
     $current_rules = $wp_rewrite->wp_rewrite_rules();
@@ -87,16 +82,20 @@ class Flizpay_Webhook_Helper
 
     $order_id = intval($data['metadata']['orderId']);
     $status = sanitize_text_field($data['status']);
+    $incoming_tx = isset($data['transactionId']) ? sanitize_text_field((string) $data['transactionId']) : '';
     $order = wc_get_order($order_id);
 
     if (!$order) {
       wp_send_json_error('Order not found', 404);
     }
 
-    // Ensure payment method is set correctly regardless of status
-    if ($order->get_payment_method() !== 'flizpay') {
-      $order->set_payment_method('flizpay');
-      $order->set_payment_method_title('FLIZpay');
+    if (!$this->is_tx_authorized_for_order($order, $incoming_tx)) {
+      $order->add_order_note(sprintf(
+        'FLIZpay webhook rejected: transactionId %s is not in this order\'s issued list',
+        $incoming_tx !== '' ? $incoming_tx : '(missing)'
+      ));
+      wp_send_json_success(array('accepted' => false), 200);
+      return;
     }
 
     if ($status === 'completed') {
@@ -110,15 +109,37 @@ class Flizpay_Webhook_Helper
     $order->save();
   }
 
+  /**
+   * A webhook is authorized only when its transactionId is one the plugin
+   * recorded via process_payment for this specific order.
+   */
+  private function is_tx_authorized_for_order(\WC_Order $order, string $tx_id)
+  {
+    if (!is_string($tx_id) || $tx_id === '') {
+      return false;
+    }
+    $issued = $order->get_meta('_flizpay_issued_tx_ids');
+    if (!is_array($issued) || empty($issued)) {
+      return false;
+    }
+    return in_array($tx_id, $issued, true);
+  }
+
   public function webhook_authenticate($data)
   {
     $key = $this->gateway->get_option('flizpay_webhook_key');
 
-    if (isset($_SERVER['HTTP_X_FLIZ_SIGNATURE'])) {
-      $signature = sanitize_text_field(wp_unslash($_SERVER['HTTP_X_FLIZ_SIGNATURE']));
-      $signedData = hash_hmac('sha256', wp_json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), $key);
-      return hash_equals($signature, $signedData);
+    if (!is_string($key) || strlen($key) < 32) {
+      return false;
     }
+
+    if (!isset($_SERVER['HTTP_X_FLIZ_SIGNATURE'])) {
+      return false;
+    }
+
+    $signature = sanitize_text_field(wp_unslash($_SERVER['HTTP_X_FLIZ_SIGNATURE']));
+    $signedData = hash_hmac('sha256', wp_json_encode($data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES), $key);
+    return hash_equals($signature, $signedData);
   }
 
   private function update_webhook_status($status)

--- a/public/class-flizpay-public.php
+++ b/public/class-flizpay-public.php
@@ -98,8 +98,26 @@ class Flizpay_Public
      */
     public function enqueue_scripts()
     {
+        if (!$this->is_checkout_flow_page()) {
+            return;
+        }
 
         $this->enqueue_checkout_scripts();
+    }
+
+    /**
+     * True only on pages where the customer has a known order context —
+     * the checkout page, the order-pay endpoint (paying for an existing order
+     * via a WC-verified key URL), or the order-received (thank-you) page.
+     */
+    private function is_checkout_flow_page()
+    {
+        if (!function_exists('is_checkout')) {
+            return false;
+        }
+        return is_checkout()
+            || (function_exists('is_wc_endpoint_url') && is_wc_endpoint_url('order-pay'))
+            || (function_exists('is_order_received_page') && is_order_received_page());
     }
 
     // Enqueues the public script for the checkout page
@@ -142,19 +160,49 @@ class Flizpay_Public
     public function flizpay_order_finish()
     {
         check_ajax_referer('order_finish_nonce', 'nonce');
-        if (isset($_POST['order_id'])) {
-            $order_id = sanitize_text_field(wp_unslash($_POST['order_id']));
-            $order = wc_get_order($order_id);
-            $status = $order ? $order->get_status() : 'pending';
 
-            echo wp_json_encode(
-                array(
-                    'status' => $status,
-                    'url' => $status === 'processing' ? $order->get_checkout_order_received_url() : 'https://checkout.flizpay.de/failed',
-                )
-            );
+        if (!isset($_POST['order_id'])) {
+            wp_send_json_error('Missing order_id', 400);
         }
+
+        $order_id = absint(wp_unslash($_POST['order_id']));
+        $order = $order_id ? wc_get_order($order_id) : null;
+
+        // Bind the lookup to the current customer: either a logged-in owner, or the
+        // current guest session's "order_awaiting_payment" set during process_payment.
+        if (!$order || !$this->customer_can_view_order($order)) {
+            wp_send_json_error('Forbidden', 403);
+        }
+
+        $status = $order->get_status();
+
+        echo wp_json_encode(
+            array(
+                'status' => $status,
+                'url' => $status === 'processing' ? $order->get_checkout_order_received_url() : 'https://checkout.flizpay.de/failed',
+            )
+        );
         die;
+    }
+
+    /**
+     * True only when the request can legitimately ask about this order.
+     * Logged-in users must own the order; guests must have the order set as
+     * "awaiting payment" in their WC session (this is set by WC during
+     * process_payment and by the order-pay endpoint after WC verifies the key).
+     */
+    private function customer_can_view_order(\WC_Order $order)
+    {
+        if (is_user_logged_in() && (int) $order->get_customer_id() === get_current_user_id()) {
+            return true;
+        }
+
+        if (!function_exists('WC') || !WC()->session) {
+            return false;
+        }
+
+        $awaiting = WC()->session->get('order_awaiting_payment');
+        return $awaiting && (int) $awaiting === (int) $order->get_id();
     }
 
     /**


### PR DESCRIPTION
## Description

Security audit hardening

### F-001 (critical) — Forged webhooks on unconfigured installs
**Audit:** see audit notes

**Outcome:** `webhook_authenticate()` rejects before computing the HMAC if the stored key is missing or shorter than 32 characters. Forged-webhook attack against unconfigured installs is no longer possible.

### F-002 (high) — Webhook completion not bound to a stored transaction
**Audit:** see audit notes

**Outcome:** `process_payment` stores the backend's `transactionId` in `_flizpay_issued_tx_ids` order meta. `finish_order()` rejects (silent 200 + order note) any webhook whose `transactionId` is not in that order's issued list. The auto-rewrite-payment-method block is removed. Cross-order spoofing and "convert non-FLIZ order to FLIZ" attacks are both closed.

Multiple tx_ids per order are supported (the "Pay for order" retry flow legitimately issues new transactions).

### F-004 (high) — Anonymous polling endpoint leaks order data
**Audit:** see audit notes

**Outcome:** The handler now requires the request to belong to a logged-in order owner OR to the current guest session's `order_awaiting_payment` (set by WC during `process_payment` and by the order-pay endpoint after WC's own key check). Anonymous probes get 403. Scripts and nonce are enqueued only on checkout / order-pay / order-received pages.

### F-005 (low) — Rewrite rules flushed on every request
**Audit:** see audit notes

**Outcome:** Removed the empty-key branch. Flushing now happens only on first activation (via existing activator) or if the rule has gone missing from persisted rewrite rules.

## Backwards compatibility
Hard cutover. Orders placed under the previous plugin version have no `_flizpay_issued_tx_ids` meta. The narrow affected cohort — customer's FLIZ-app session for an abandoned transaction outlives the upgrade AND they complete it in-app without returning to WC checkout — will see late-arriving webhooks rejected. Stuck orders recoverable via WC admin "mark as paid".

> Merchants with long-lived pending orders should drain them before updating.

## Out of scope
- Amount/currency reconciliation (originally proposed as F-003) was dropped — F-002's tx-id binding makes it redundant against the audit's stated attack.

## Test plan
- [x] **F-001:** POST `/flizpay-webhook/` with empty key + matching empty-key HMAC → expect 401, gateway state unchanged
- [x] **F-002 negative:** Valid-signed completion webhook with random `transactionId` and correct `orderId` → expect 200 + `accepted: false`, order unchanged, order note added
- [x] **F-002 positive:** Real checkout → payment → order completes
- [x] **F-002 retry:** Cancel a payment → "Pay for order" link → new tx → completes (issued list has 2 ids)
- [x] **F-004:** Visit non-checkout page → `flizpay_frontend` not localized. Anonymous POST with valid nonce but no matching session → 403
- [x] **F-005:** Empty webhook key, hit any frontend page twice → `flush_rewrite_rules()` not called the second time
- [x] `php -l` clean on all modified files

---

## Notion Ticket
[NOTION TICKET](https://www.notion.so/security-Woocommerce-plugin-audit-3670aa2641a78064bd1fea1a0282fbd1?v=1064dfb8616e471a856eb063ccf8fec1&source=copy_link)

---